### PR TITLE
fixed push not having a registry

### DIFF
--- a/pkg/kf/commands/apps/push.go
+++ b/pkg/kf/commands/apps/push.go
@@ -84,7 +84,7 @@ func NewPushCommand(p *config.KfParams, pusher kf.Pusher, b SrcImageBuilder) *co
 					}
 				}
 
-				imageName = fmt.Sprintf("src-%s-%d%d", appName, time.Now().UnixNano(), rand.Uint64())
+				imageName = fmt.Sprintf("%s/src-%s-%d%d", containerRegistry, appName, time.Now().UnixNano(), rand.Uint64())
 				if err := b.BuildSrcImage(path, imageName); err != nil {
 					cmd.SilenceUsage = true
 					return err


### PR DESCRIPTION
Push was failing because the registry wasn't being appended to the imagename so it was automaticlly being resolved to Docker Hub in the push command. Now we're adding it.