### PR TITLE
all: adds apps end to end tests and sample apps

### DIFF
--- a/pkg/kf/commands/apps/apps_test.go
+++ b/pkg/kf/commands/apps/apps_test.go
@@ -163,6 +163,7 @@ func TestAppsCommand(t *testing.T) {
 				Namespace: tc.namespace,
 				Output:    buffer,
 			}, fakeLister)
+			c.SetOutput(buffer)
 
 			c.SetArgs(tc.args)
 			gotErr := c.Execute()

--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -1,0 +1,230 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/GoogleCloudPlatform/kf/pkg/kf/internal/testutil"
+)
+
+// TestIntegration_Doctor runs the doctor command. It ensures the cluster the
+// tests are running against is in good shape.
+func TestIntegration_Doctor(t *testing.T) {
+	t.Parallel()
+	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
+		kf.Doctor(ctx)
+	})
+}
+
+// TestIntegration_Push pushes the echo app (via --built-in command), lists it
+// to ensure it can find a domain, uses the proxy command and then posts to
+// it. It finally deletes the app.
+func TestIntegration_Push(t *testing.T) {
+	t.Parallel()
+	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
+		appName := fmt.Sprintf("integration-echo-%d", time.Now().UnixNano())
+
+		// Push an app and then clean it up. This pushes the echo app which
+		// replies with the same body that was posted.
+		kf.Push(ctx, appName, map[string]string{
+			"--built-in":           "",
+			"--path":               filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
+			"--container-registry": fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+		})
+		defer kf.Delete(ctx, appName)
+
+		// List the apps and make sure we can find a domain.
+		Logf(t, "ensuring app has domain...")
+		apps := kf.Apps(ctx)
+		if apps[appName].Domain == "" {
+			t.Fatalf("empty domain")
+		}
+		Logf(t, "done ensuring app has domain.")
+
+		// Hit the app via the proxy. This makes sure the app is handling
+		// traffic as expected and ensures the proxy works. We use the proxy
+		// for two reasons:
+		// 1. Test the proxy.
+		// 2. Tests work even if a domain isn't setup.
+		Logf(t, "hitting echo app to ensure its working...")
+
+		// TODO: Use port 0 so that we don't have to worry about port
+		// collisions. This doesn't work yet:
+		// https://github.com/poy/kf/issues/46
+		go kf.Proxy(ctx, appName, 8080)
+		resp := RetryPost(ctx, t, "http://localhost:8080", 5*time.Second, strings.NewReader("testing"))
+		defer resp.Body.Close()
+		AssertEqual(t, "status code", http.StatusOK, resp.StatusCode)
+		data, err := ioutil.ReadAll(resp.Body)
+		AssertNil(t, "body error", err)
+		AssertEqual(t, "body", "testing", string(data))
+		Logf(t, "done hitting echo app to ensure its working.")
+	})
+}
+
+// TestIntegration_Delete pushes an app and then deletes it. It then makes
+// sure it is marked as "Deleting".
+func TestIntegration_Delete(t *testing.T) {
+	t.Parallel()
+	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
+		appName := fmt.Sprintf("integration-echo-%d", time.Now().UnixNano())
+
+		// Push an app and then clean it up. This pushes the echo app which
+		// simplies replies with the same body that was posted.
+		kf.Push(ctx, appName, map[string]string{
+			"--built-in":           "",
+			"--path":               filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
+			"--container-registry": fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+		})
+
+		// This is only in place for cleanup if the test fails.
+		defer kf.Delete(ctx, appName)
+
+		// List the apps and make sure we can find the app.
+		Logf(t, "ensuring app is there...")
+		_, ok := kf.Apps(ctx)[appName]
+		AssertEqual(t, "app presense", true, ok)
+		Logf(t, "done ensuring app is there.")
+
+		// Delete the app.
+		kf.Delete(ctx, appName)
+
+		// Make sure the app is "deleting"
+		// List the apps and make sure we can find the app.
+		Logf(t, "ensuring app is deleting...")
+		app := kf.Apps(ctx)[appName]
+		AssertEqual(t, "reason", "Deleting", app.Reason)
+		Logf(t, "done ensuring app is deleting.")
+	})
+}
+
+// TestIntegration_Envs pushes the env sample app. It sets two variables while
+// pushing, and another via SetEnv. It then reads them via Env. It then unsets
+// one via Unset and reads them again via Env.
+func TestIntegration_Envs(t *testing.T) {
+	t.Parallel()
+	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
+		appName := fmt.Sprintf("integration-envs-%d", time.Now().UnixNano())
+
+		// CheckVars uses Env and the output of the app to ensure the expected
+		// variables. It will retry for 5 seconds if the environment variables
+		// aren't returning the correct values. This is to give the
+		// enventually consistent system time to catch-up.
+		checkVars := func(expectedVars map[string]string, absentVars []string) {
+			ctx, _ = context.WithTimeout(ctx, 30*time.Second)
+			var success bool
+			for !success {
+				select {
+				case <-ctx.Done():
+					t.Fatalf("context cancelled before reaching sucessful check")
+				default:
+				}
+
+				// List the environment variables and ensure they are all
+				// present.
+				envs := kf.Env(ctx, appName)
+
+				// The envs app will return all its environment variables as
+				// JSON. This checks to make sure everything is ACTUALLY being
+				// set from the app's perspective.
+				Logf(t, "hitting env app to check the envs...")
+				resp := RetryPost(ctx, t, "http://localhost:8081", 5*time.Second, nil)
+				defer resp.Body.Close()
+				AssertEqual(t, "status code", http.StatusOK, resp.StatusCode)
+				var appEnvs map[string]string
+				AssertNil(t, "json", json.NewDecoder(resp.Body).Decode(&appEnvs))
+				Logf(t, "done hitting env app to check the envs.")
+
+				// Check all the environment variables.
+				success = true
+				for k, v := range expectedVars {
+					if envs[k] != v {
+						Logf(t, "wrong: %s != %s", envs[k], v)
+						success = false
+						break
+					}
+					if appEnvs[k] != v {
+						Logf(t, "wrong: %s != %s", appEnvs[k], v)
+						success = false
+						break
+					}
+				}
+
+				// Ensure all of the absentVars are NOT there (used to test
+				// unset-env).
+				for _, k := range absentVars {
+					if _, ok := envs[k]; ok {
+						Logf(t, "wrong: %s still is present", k)
+						success = false
+						break
+					}
+					if _, ok := appEnvs[k]; ok {
+						Logf(t, "wrong: %s still is present", k)
+						success = false
+						break
+					}
+				}
+
+				// No need to bombard it.
+				if !success {
+					time.Sleep(100 * time.Millisecond)
+				}
+			}
+		}
+
+		// Push an app and then clean it up. This pushes the envs app which
+		// returns the set environment variables via JSON. Set two environment
+		// variables (ENV1 and ENV2).
+		kf.Push(ctx, appName, map[string]string{
+			"--built-in":           "",
+			"--path":               filepath.Join(RootDir(ctx, t), "./samples/apps/envs"),
+			"--container-registry": fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+			"--env":                "ENV1=VALUE1",
+			"--env=ENV2=VALUE2":    "",
+		})
+
+		// This is only in place for cleanup if the test fails.
+		defer kf.Delete(ctx, appName)
+
+		// TODO: Use port 0 so that we don't have to worry about port
+		// collisions. This doesn't work yet:
+		// https://github.com/poy/kf/issues/46
+		go kf.Proxy(ctx, appName, 8081)
+
+		checkVars(map[string]string{
+			"ENV1": "VALUE1", // Set on push
+			"ENV2": "VALUE2", // Set on push
+		}, nil)
+
+		// Unset the environment variables ENV1.
+		kf.UnsetEnv(ctx, appName, "ENV1")
+
+		// Overwrite ENV2 via set-env
+		kf.SetEnv(ctx, appName, "ENV2", "OVERWRITE2")
+
+		checkVars(map[string]string{
+			"ENV2": "OVERWRITE2", // Set on push and overwritten via set-env
+		}, []string{"ENV1"})
+	})
+}

--- a/pkg/kf/commands/buildpacks/buildpacks_test.go
+++ b/pkg/kf/commands/buildpacks/buildpacks_test.go
@@ -80,6 +80,7 @@ func TestBuildpacks(t *testing.T) {
 				fake,
 			)
 			cmd.SetArgs(tc.Args)
+			cmd.SetOutput(&buffer)
 
 			gotErr := cmd.Execute()
 			if gotErr != nil || tc.ExpectedErr != nil {

--- a/pkg/kf/internal/testutil/integration.go
+++ b/pkg/kf/internal/testutil/integration.go
@@ -1,0 +1,573 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	// EnvGcpProjectID is the environment variable used to store the GCP
+	// project ID for the integration tests. If this is not set, then the
+	// integration tests are skipped.
+	EnvGcpProjectID = "GCP_PROJECT_ID"
+)
+
+// GCPProjectID returns the configured GCP Project ID.
+func GCPProjectID() string {
+	return os.Getenv(EnvGcpProjectID)
+}
+
+// RunIntegrationTest skips the tests if testing.Short() is true (via --short
+// flag) or if GCP_PROJECT_ID is not set. Otherwise it runs the given test.
+func RunIntegrationTest(t *testing.T, test func(ctx context.Context, t *testing.T)) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip()
+	}
+
+	projID := os.Getenv(EnvGcpProjectID)
+	if projID == "" {
+		t.Skipf("%s is required for integration tests... Skipping...", EnvGcpProjectID)
+	}
+
+	// Setup context that will allow us to cleanup if the user wants to
+	// cancel the tests.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Give everything time to clean up.
+	defer time.Sleep(time.Second)
+	defer cancel()
+
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, os.Kill)
+		<-c
+		t.Log("Signal received... Cleaning up... (Hit Ctrl-C again to quit immediately)")
+		cancel()
+		<-c
+		os.Exit(1)
+	}()
+
+	test(ctx, t)
+}
+
+// KfTestConfig is a configuration for a Kf Test.
+type KfTestConfig struct {
+	Args []string
+	Env  map[string]string
+}
+
+// KfTestOutput is the output from `kf`. Note, this output is while kf is
+// running.
+type KfTestOutput struct {
+	Stdout io.Reader
+	Stderr io.Reader
+	Stdin  io.Writer
+	Done   <-chan struct{}
+}
+
+func kf(ctx context.Context, t *testing.T, binaryPath string, cfg KfTestConfig) (KfTestOutput, <-chan error) {
+	t.Helper()
+
+	cmd := exec.CommandContext(ctx, binaryPath, cfg.Args...)
+	for name, value := range cfg.Env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", name, value))
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("failed to fetch Stdout pipe: %s", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatalf("failed to fetch Stderr pipe: %s", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("failed to fetch Stdin pipe: %s", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start kf: %s", err)
+	}
+
+	done := make(chan struct{})
+	errs := make(chan error, 1)
+	go func() {
+		errs <- cmd.Wait()
+		close(done)
+	}()
+
+	return KfTestOutput{
+		Stdout: stdout,
+		Stderr: stderr,
+		Stdin:  stdin,
+		Done:   done,
+	}, errs
+}
+
+// KfInvoker will synchronously invoke `kf` with the given configuration.
+type KfInvoker func(context.Context, *testing.T, KfTestConfig) (KfTestOutput, <-chan error)
+
+// KfTest is a test ran by RunKfTest.
+type KfTest func(ctx context.Context, t *testing.T, kf *Kf)
+
+// RunKfTest runs 'kf' for integration tests. It first copmiles 'kf' and then
+// launches it as a sub-process. It will set the args and environment
+// variables accordingly. It will run the given test with the resulting
+// STDOUT, STDERR and STDIN. It will cleanup the sub-process on completion via
+// the context.
+func RunKfTest(t *testing.T, test KfTest) {
+	t.Helper()
+	RunIntegrationTest(t, func(ctx context.Context, t *testing.T) {
+		t.Helper()
+		kfPath := CompileKf(ctx, t)
+
+		kf := KF(t, func(ctx context.Context, t *testing.T, cfg KfTestConfig) (KfTestOutput, <-chan error) {
+			return kf(ctx, t, kfPath, cfg)
+		})
+
+		test(ctx, t, kf)
+	})
+}
+
+// CompileKf compiles the `kf` binary. It returns a string to the resulting
+// binary.
+func CompileKf(ctx context.Context, t *testing.T) string {
+	t.Helper()
+	return Compile(ctx, t, "./cmd/kf")
+}
+
+// Compile compiles a path in the repo. It returns a path to the resulting
+// binary. codePath must be relative to RootDir.
+func Compile(ctx context.Context, t *testing.T, codePath string) string {
+	t.Helper()
+
+	var err error
+	codePath, err = filepath.Abs(filepath.Join(RootDir(ctx, t), codePath))
+	if err != nil {
+		t.Fatalf("failed to convert to absolute path: %s", err)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get CWD: %s", err)
+	}
+
+	codePath, err = filepath.Rel(wd, codePath)
+	if err != nil {
+		t.Fatalf("failed to get relative code path: %s", err)
+	}
+	codePath = "./" + codePath
+
+	tmpDir, err := ioutil.TempDir("", "kf_test_compile")
+	if err != nil {
+		t.Fatalf("failed to create a temp dir: %s", err)
+	}
+
+	go func() {
+		<-ctx.Done()
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("WARNING: failed to cleanup temp dir: %s: %s", tmpDir, err)
+		}
+	}()
+
+	outputPath := filepath.Join(tmpDir, "out")
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", outputPath, ".")
+	cmd.Dir = codePath
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to go build (err=%s): %s", err, output)
+	}
+
+	return outputPath
+}
+
+// RootDir uses git to find the root of the directory. This is useful for
+// tests (especially integration ones that compile things).
+func RootDir(ctx context.Context, t *testing.T) string {
+	t.Helper()
+
+	ctx, _ = context.WithTimeout(ctx, 3*time.Second)
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("failed to get Stdout pipe for RootDir: %s", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start command to get RootDir %s", err)
+	}
+
+	data, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		t.Fatalf("failed to read Stdout pipe for RootDir: %s", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("failed to get RootDir %s", err)
+	}
+
+	return strings.TrimSpace(string(data))
+}
+
+// PanicOnError launches a go routine and waits for either the context or an
+// error. An error will result in a panic. Why a panic in a test? t.Fatal is
+// not thread safe. T.Failed() is thread safe, therefore we can use that to
+// prevent the panic.
+func PanicOnError(ctx context.Context, t *testing.T, messagePrefix string, errs <-chan error) {
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case err := <-errs:
+			if err != nil {
+				if t.Failed() {
+					Logf(t, "%s: %s", messagePrefix, err)
+					return
+				} else {
+					panic(fmt.Sprintf("%s: %s", messagePrefix, err))
+				}
+			}
+		}
+	}()
+}
+
+// CombinedOutputSr writes the Stdout and Stderr string. It will return when
+// ctx is done.
+func CombineOutputStr(ctx context.Context, t *testing.T, out KfTestOutput) []string {
+	lines := CombineOutput(ctx, t, out)
+
+	var result []string
+	for {
+		select {
+		case <-ctx.Done():
+			return result
+		case <-out.Done:
+			return result
+		case line, ok := <-lines:
+			if ok {
+				result = append(result, line)
+			}
+		}
+	}
+}
+
+// CombinedOutput writes the Stdout and Stderr to a channel for each line.
+func CombineOutput(ctx context.Context, t *testing.T, out KfTestOutput) <-chan string {
+	lines := make(chan string)
+
+	var wg sync.WaitGroup
+	f := func(r io.Reader) {
+		defer wg.Done()
+		s := bufio.NewScanner(r)
+		for s.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			case lines <- s.Text():
+			}
+		}
+	}
+
+	wg.Add(2)
+	go f(out.Stdout)
+	go f(out.Stderr)
+	go func() {
+		wg.Wait()
+		close(lines)
+	}()
+
+	return lines
+}
+
+// Logf will write to Stderr if testing.Verbose is true and t.Log otherwise.
+// This is so logs will stream out instead of only being displayed at the end
+// of the test.
+func Logf(t *testing.T, format string, i ...interface{}) {
+	if testing.Verbose() {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf(format, i...))
+		return
+	}
+
+	t.Logf(format, i...)
+}
+
+// StreamOutput writes the output of KfTestOutput to the testing.Log if
+// testing.Verbose is false and Stderr otherwise.
+func StreamOutput(ctx context.Context, t *testing.T, out KfTestOutput) {
+	lines := CombineOutput(ctx, t, out)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-out.Done:
+			return
+		case line, ok := <-lines:
+			if ok {
+				Logf(t, line)
+			}
+		}
+	}
+}
+
+// RetryPost will post until successful, duration has been reached or context is
+// done.
+func RetryPost(ctx context.Context, t *testing.T, addr string, duration time.Duration, body io.Reader) *http.Response {
+	ctx, _ = context.WithTimeout(ctx, duration)
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context cancelled")
+		default:
+		}
+
+		req, err := http.NewRequest(http.MethodPost, addr, body)
+		if err != nil {
+			t.Fatalf("failed to create request: %s", err)
+		}
+		req = req.WithContext(ctx)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			Logf(t, "failed to post (retrying...): %s", err)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		return resp
+	}
+
+	return nil
+}
+
+// Kf provides a DSL for running integration tests.
+type Kf struct {
+	t  *testing.T
+	kf KfInvoker
+}
+
+// KF returns a kf.
+func KF(t *testing.T, kf KfInvoker) *Kf {
+	return &Kf{
+		t:  t,
+		kf: kf,
+	}
+}
+
+// Push pushes an application.
+func (k *Kf) Push(ctx context.Context, appName string, flags map[string]string) {
+	k.t.Helper()
+	Logf(k.t, "pushing app %q...", appName)
+	defer Logf(k.t, "done pushing app %q.", appName)
+
+	args := []string{
+		"push",
+		appName,
+	}
+
+	for k, v := range flags {
+		if v == "" {
+			args = append(args, k)
+			continue
+		}
+
+		args = append(args, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: args,
+	})
+	PanicOnError(ctx, k.t, fmt.Sprintf("push %q", appName), errs)
+	StreamOutput(ctx, k.t, output)
+}
+
+// AppInfo is the information returned by listing an app. It is returned by
+// ListApp.
+type AppInfo struct {
+	Name   string
+	Domain string
+	Reason string
+}
+
+// Apps returns all the apps from `kf app`
+func (k *Kf) Apps(ctx context.Context) map[string]AppInfo {
+	Logf(k.t, "listing apps...")
+	defer Logf(k.t, "done listing apps.")
+	k.t.Helper()
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: []string{"apps", "--built-in"},
+	})
+	PanicOnError(ctx, k.t, "apps", errs)
+	apps := CombineOutputStr(ctx, k.t, output)
+
+	if len(apps) == 0 {
+		return nil
+	}
+
+	results := map[string]AppInfo{}
+	for _, app := range apps[1:] {
+		f := strings.Fields(app)
+		if len(f) <= 1 {
+			continue
+		}
+
+		domain := f[1]
+		if !strings.HasPrefix(domain, "http") {
+			domain = "http://" + domain
+		}
+
+		var reason string
+		if len(f) > 5 {
+			reason = f[5]
+		}
+
+		results[f[0]] = AppInfo{
+			Name:   f[0],
+			Domain: domain,
+			Reason: reason,
+		}
+	}
+
+	return results
+}
+
+// Delete deletes an application.
+func (k *Kf) Delete(ctx context.Context, appName string) {
+	k.t.Helper()
+	Logf(k.t, "deleting %q...", appName)
+	defer Logf(k.t, "done deleting %q.", appName)
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: []string{
+			"delete",
+			"--built-in",
+			appName,
+		},
+	})
+	PanicOnError(ctx, k.t, fmt.Sprintf("delete %q", appName), errs)
+	StreamOutput(ctx, k.t, output)
+}
+
+// Proxy starts a proxy for an application.
+func (k *Kf) Proxy(ctx context.Context, appName string, port int) {
+	k.t.Helper()
+	Logf(k.t, "running proxy for %q...", appName)
+	defer Logf(k.t, "done running proxy for %q.", appName)
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: []string{
+			"proxy",
+			"--built-in",
+			appName,
+			fmt.Sprintf("--port=%d", port),
+		},
+	})
+	PanicOnError(ctx, k.t, fmt.Sprintf("proxy %q", appName), errs)
+	StreamOutput(ctx, k.t, output)
+}
+
+// SetEnv sets the environment variable for an app.
+func (k *Kf) SetEnv(ctx context.Context, appName, name, value string) {
+	k.t.Helper()
+	Logf(k.t, "running set-env %s=%s for %q...", name, value, appName)
+	defer Logf(k.t, "done running set-env %s=%s for %q.", name, value, appName)
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: []string{
+			"set-env",
+			"--built-in",
+			appName,
+			name,
+			value,
+		},
+	})
+	PanicOnError(ctx, k.t, fmt.Sprintf("set-env %q", appName), errs)
+	StreamOutput(ctx, k.t, output)
+}
+
+// UnsetEnv unsets the environment variable for an app.
+func (k *Kf) UnsetEnv(ctx context.Context, appName, name string) {
+	k.t.Helper()
+	Logf(k.t, "running unset-env %s for %q...", name, appName)
+	defer Logf(k.t, "done running unset-env %s for %q.", name, appName)
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: []string{
+			"unset-env",
+			"--built-in",
+			appName,
+			name,
+		},
+	})
+	PanicOnError(ctx, k.t, fmt.Sprintf("unset-env %q", appName), errs)
+	StreamOutput(ctx, k.t, output)
+}
+
+// Env displays the environment variables for an app.
+func (k *Kf) Env(ctx context.Context, appName string) map[string]string {
+	k.t.Helper()
+	Logf(k.t, "running env for %q...", appName)
+	defer Logf(k.t, "done running env for %q.", appName)
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: []string{
+			"env",
+			"--built-in",
+			appName,
+		},
+	})
+	PanicOnError(ctx, k.t, fmt.Sprintf("env %q", appName), errs)
+	envs := CombineOutputStr(ctx, k.t, output)
+
+	if len(envs) == 0 {
+		return nil
+	}
+
+	results := map[string]string{}
+	for _, line := range envs[1:] {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		results[fields[0]] = fields[1]
+	}
+
+	return results
+}
+
+// Doctor runs the doctor command.
+func (k *Kf) Doctor(ctx context.Context) {
+	k.t.Helper()
+	Logf(k.t, "running doctor...")
+	defer Logf(k.t, "done running doctor.")
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: []string{
+			"doctor",
+			"--built-in",
+		},
+	})
+	PanicOnError(ctx, k.t, "doctor", errs)
+	StreamOutput(ctx, k.t, output)
+}

--- a/samples/apps/echo/README.md
+++ b/samples/apps/echo/README.md
@@ -1,0 +1,4 @@
+# Echo Sample App
+
+This is a Go application that returns anything POSTed to it. It is used by
+integration tests.

--- a/samples/apps/echo/go.mod
+++ b/samples/apps/echo/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleCloudPlatform/kf/samples/apps
+
+go 1.12

--- a/samples/apps/echo/main.go
+++ b/samples/apps/echo/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	log.Fatal(http.ListenAndServe(hostPort(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(w, r.Body)
+	})))
+}
+
+func hostPort() string {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	return fmt.Sprintf(":%s", port)
+}

--- a/samples/apps/envs/README.md
+++ b/samples/apps/envs/README.md
@@ -1,0 +1,4 @@
+# Envs Sample App
+
+This is a Go application that returns its JSON encoded environment variables.
+It is used by integration tests.

--- a/samples/apps/envs/go.mod
+++ b/samples/apps/envs/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleCloudPlatform/kf/samples/apps/envs
+
+go 1.12

--- a/samples/apps/envs/main.go
+++ b/samples/apps/envs/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	envs := map[string]string{}
+	for _, e := range os.Environ() {
+		x := strings.SplitN(e, "=", 2)
+		if len(x) != 2 {
+			continue
+		}
+		envs[x[0]] = x[1]
+	}
+
+	log.Fatal(http.ListenAndServe(hostPort(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(envs); err != nil {
+			log.Printf("failed to encode envs: %s", err)
+		}
+	})))
+}
+
+func hostPort() string {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	return fmt.Sprintf(":%s", port)
+}

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+
+export GCP_PROJECT_ID=$(gcloud config get-value project)
+go test --race -v ./...


### PR DESCRIPTION
part of #14

Adds end to end tests to cover the commands:
- push
- delete
- apps
- set-env
- unset-env
- env
- doctor

It adds the "envs" and "echo" sample Go apps. These apps are used by the
integration tests.

The integration tests are ran when the environment variable
GCP_PROJECT_ID is set while running the tests. If it is not set, they
will be skipped. They can also be skipped with the "--short" flag. The
tests run against a running knative cluster and assume GKE.

They are currently flaky due to https://github.com/poy/kf/issues/47