### PR TITLE
samples/plugins/gke: add ClusterRoleBinding for servicecatalog.k8s.io…

### DIFF
--- a/pkg/kf/commands/generator/registrar.go
+++ b/pkg/kf/commands/generator/registrar.go
@@ -73,6 +73,11 @@ func Convert(containerRegistry, commandSetName string, output io.Writer) {
 			"kind":     "ClusterRole",
 			"name":     "knative-serving-admin",
 		}),
+		clusterRoleBinding("service-catalog-servicecatalog-controller-manager", map[string]interface{}{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "ClusterRole",
+			"name":     "servicecatalog.k8s.io:controller-manager",
+		}),
 		jsonToYaml(buildCommandSet(List(), containerRegistry, commandSetName)),
 	} {
 		if err := encoder.Encode(y); err != nil {


### PR DESCRIPTION
This adds a ClusterRoleBinding for
servicecatalog.k8s.io:controller-manager. This is now required so the
push command can inject VCAP_SERVICES.

fixes #64