### PR TITLE
created client generator

### DIFF
--- a/pkg/kf/internal/tools/clientgen/client.go
+++ b/pkg/kf/internal/tools/clientgen/client.go
@@ -1,0 +1,77 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// go:generate ../option-builder.go
+
+package clientgen
+
+import (
+	"bytes"
+	"text/template"
+)
+
+type ClientParams struct {
+	// Package is the package the client will be generated in.
+	Package string `yaml:"package"`
+
+	// Imports is used for imports into the client.
+	Imports map[string]string `yaml:"imports"`
+
+	// Kubernetes holds information about the backing API.
+	Kubernetes struct {
+		// Kind is the kind of the resource.
+		Kind string `yaml:"kind"`
+		// Version is the version of the resource kf supports.
+		Version string `yaml:"version"`
+		// Namespaced indicates whether this object is namespaced or global.
+		Namespaced bool `yaml:"namespaced"`
+		// Plural contains the pluralizataion of kind. If blank, default of Kind+"s"
+		// is assumed.
+		Plural string `yaml:"plural"`
+	} `yaml:"kubernetes"`
+
+	// CF contains information about this resource from a CF side.
+	CF struct {
+		// The name of the CF type.
+		Name string `yaml:"name"`
+	} `yaml:"cf"`
+
+	// Type is the go type of the resource. This MUST be imported using Imports.
+	Type string `yaml:"type"`
+
+	// ClientType is the go type of the Kubernetes client. This MUST be imported using Imports.
+	ClientType string `yaml:"clienttype"`
+}
+
+func (f *ClientParams) Render() ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if f.Kubernetes.Plural == "" {
+		f.Kubernetes.Plural = f.Kubernetes.Kind + "s"
+	}
+
+	templates := []*template.Template{
+		headerTemplate,
+		functionalUtilTemplate,
+		clientTemplate,
+	}
+
+	for _, tmpl := range templates {
+		if err := tmpl.Execute(buf, f); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/kf/internal/tools/clientgen/client.go
+++ b/pkg/kf/internal/tools/clientgen/client.go
@@ -47,11 +47,11 @@ type ClientParams struct {
 		Name string `yaml:"name"`
 	} `yaml:"cf"`
 
-	// Type is the go type of the resource. This MUST be imported using Imports.
+	// Type is the Go type of the resource. This MUST be imported using Imports.
 	Type string `yaml:"type"`
 
-	// ClientType is the go type of the Kubernetes client. This MUST be imported using Imports.
-	ClientType string `yaml:"clienttype"`
+	// ClientType is the Go type of the Kubernetes client. This MUST be imported using Imports.
+	ClientType string `yaml:"clientType"`
 }
 
 func (f *ClientParams) Render() ([]byte, error) {

--- a/pkg/kf/internal/tools/clientgen/common-options.yml
+++ b/pkg/kf/internal/tools/clientgen/common-options.yml
@@ -1,0 +1,45 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains common options for clients.
+# It is generated into each client individually so clients can add additional
+# modification functions to better suit the functionality of their specific
+# controller. For example, some controllers might support filtering based on
+# a particular property while others don't.
+---
+package: MUST_BE_OVERRIDDEN
+imports: {}
+configs:
+- name: Create
+- name: Update
+- name: Get
+- name: Delete
+  options:
+  - name: ForegroundDeletion
+    type: bool
+    description: If the resource should be deleted in the foreground.
+  - name: DeleteImmediately
+    type: bool
+    description: If the resource should be deleted immediately.
+- name: List
+  options:
+  - name: labelSelector
+    type: "map[string]string"
+    description: A label selector.
+  - name: fieldSelector
+    type: "map[string]string"
+    description: A selector on the resource's fields.
+  - name: filters
+    type: "[]Predicate"
+    description: Additional filters to apply.

--- a/pkg/kf/internal/tools/clientgen/genclient.go
+++ b/pkg/kf/internal/tools/clientgen/genclient.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build ignore
+
+package main
+
+import (
+	"go/format"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/internal/tools/clientgen"
+	"gopkg.in/yaml.v2"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		panic("use: genclient.go /path/to/defn.yml")
+	}
+
+	optionsPath := os.Args[1]
+
+	contents, err := ioutil.ReadFile(optionsPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	params := &clientgen.ClientParams{}
+	if err := yaml.Unmarshal(contents, params); err != nil {
+		log.Fatal(err)
+		return
+	}
+
+	buf, err := params.Render()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+
+	formatted, err := format.Source(buf)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+
+	f, err := os.Create("zz_generated.client.go")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	f.Write(formatted)
+}

--- a/pkg/kf/internal/tools/clientgen/genclient.go
+++ b/pkg/kf/internal/tools/clientgen/genclient.go
@@ -28,7 +28,7 @@ import (
 
 func main() {
 	if len(os.Args) != 2 {
-		panic("use: genclient.go /path/to/defn.yml")
+		log.Fatal("use: genclient.go /path/to/defn.yml")
 	}
 
 	optionsPath := os.Args[1]

--- a/pkg/kf/internal/tools/clientgen/gentest/client.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/client.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gentest contains tests for the client generator.
+package gentest
+
+import v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+//go:generate go run ../../option-builder/option-builder.go --pkg gentest ../common-options.yml zz_generated.clientoptions.go
+//go:generate go run ../genclient.go client.yml
+
+type ClientExtension interface {
+}
+
+// NewExampleClient creates an example client with a mutator and membership
+// validator that filter based on a label.
+func NewExampleClient(mockK8s v1.SecretsGetter) Client {
+	return &coreClient{
+		kclient: mockK8s,
+		upsertMutate: MutatorList{
+			LabelSetMutator(map[string]string{"is-a": "OperatorConfig"}),
+		},
+		membershipValidator: LabelEqualsPredicate("is-a", "OperatorConfig"),
+	}
+}

--- a/pkg/kf/internal/tools/clientgen/gentest/client.yml
+++ b/pkg/kf/internal/tools/clientgen/gentest/client.yml
@@ -7,6 +7,6 @@ kubernetes:
   version: "v1"
   namespaced: true
 type: "v1.Secret"
-clienttype: "cv1.SecretsGetter"
+clientType: "cv1.SecretsGetter"
 cf:
   name: "OperatorConfig"

--- a/pkg/kf/internal/tools/clientgen/gentest/client.yml
+++ b/pkg/kf/internal/tools/clientgen/gentest/client.yml
@@ -1,0 +1,12 @@
+# This file contains options for genfunctional.go
+---
+package: gentest
+imports: {"k8s.io/api/core/v1":"v1", "k8s.io/client-go/kubernetes/typed/core/v1": "cv1"}
+kubernetes:
+  kind: "Secret"
+  version: "v1"
+  namespaced: true
+type: "v1.Secret"
+clienttype: "cv1.SecretsGetter"
+cf:
+  name: "OperatorConfig"

--- a/pkg/kf/internal/tools/clientgen/gentest/client_test.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/client_test.go
@@ -1,0 +1,260 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gentest
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/testutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	cv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func TestAllPredicate(t *testing.T) {
+	pass := func(obj *v1.Secret) bool {
+		return true
+	}
+
+	fail := func(obj *v1.Secret) bool {
+		return false
+	}
+
+	cases := map[string]struct {
+		Children []Predicate
+		Expected bool
+	}{
+		"empty true": {
+			Children: []Predicate{},
+			Expected: true,
+		},
+		"pass": {
+			Children: []Predicate{pass},
+			Expected: true,
+		},
+		"fail": {
+			Children: []Predicate{fail},
+			Expected: false,
+		},
+		"mixed": {
+			Children: []Predicate{pass, fail, pass},
+			Expected: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			pred := AllPredicate(tc.Children...)
+			actual := pred(nil)
+			testutil.AssertEqual(t, "predicate result", tc.Expected, actual)
+		})
+	}
+}
+
+func ExampleList_Filter() {
+	first := v1.Secret{}
+	first.Name = "ok"
+
+	second := v1.Secret{}
+	second.Name = "name-too-long-to-pass"
+
+	list := List{first, second}
+
+	filtered := list.Filter(func(s *v1.Secret) bool {
+		return len(s.Name) < 8
+	})
+
+	fmt.Println("Results")
+	for _, v := range filtered {
+		fmt.Println("-", v.Name)
+	}
+
+	// Output: Results
+	// - ok
+}
+
+func ExampleMutatorList_Apply() {
+	mutators := MutatorList{
+		func(s *v1.Secret) error {
+			s.Name = "Name"
+			return nil
+		},
+		func(s *v1.Secret) error {
+			return errors.New("some-error")
+		},
+	}
+	res := v1.Secret{}
+	err := mutators.Apply(&res)
+
+	fmt.Println("Error:", err)
+	fmt.Println("Mutated name:", res.Name)
+
+	// Output: Error: some-error
+	// Mutated name: Name
+}
+
+func ExampleLabelSetMutator() {
+	out := &v1.Secret{}
+	managedAdder := LabelSetMutator(map[string]string{"managed-by": "kf"})
+
+	managedAdder(out)
+	fmt.Printf("Labels: %v", out.Labels)
+
+	// Output: Labels: map[managed-by:kf]
+}
+
+func ExampleLabelEqualsPredicate() {
+	out := &v1.Secret{}
+	out.Labels = map[string]string{"managed-by": "not kf"}
+	pred := LabelEqualsPredicate("managed-by", "kf")
+
+	fmt.Printf("Not Equal: %v\n", pred(out))
+
+	out.Labels["managed-by"] = "kf"
+	fmt.Printf("Equal: %v\n", pred(out))
+
+	// Output: Not Equal: false
+	// Equal: true
+}
+
+func ExampleLabelsContainsPredicate() {
+	out := &v1.Secret{}
+	out.Labels = map[string]string{"my-label": ""}
+
+	mylabelpred := LabelsContainsPredicate("my-label")
+	missinglabelpred := LabelsContainsPredicate("missing")
+
+	fmt.Printf("Contained: %v\n", mylabelpred(out))
+	fmt.Printf("Not Contained: %v\n", missinglabelpred(out))
+
+	// Output: Contained: true
+	// Not Contained: false
+}
+
+func TestClient_invariant(t *testing.T) {
+	// This test validates that the filters and mutators are applied to read and
+	// write operations.
+	mockK8s := testclient.NewSimpleClientset().CoreV1()
+
+	invalid := &v1.Secret{}
+	invalid.Name = "does-not-belong"
+
+	if _, err := mockK8s.Secrets("default").Create(invalid); err != nil {
+		t.Fatal(err)
+	}
+
+	secretsClient := NewExampleClient(mockK8s)
+
+	t.Run("create", func(t *testing.T) {
+		good := &v1.Secret{}
+		good.Name = "created-through-client"
+
+		if _, err := secretsClient.Create("default", good); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		out, err := secretsClient.List("default")
+		testutil.AssertNil(t, "list err", err)
+
+		testutil.AssertEqual(t, "secret count", 1, len(out))
+	})
+
+	t.Run("get", func(t *testing.T) {
+		_, err := secretsClient.Get("default", "does-not-belong")
+		testutil.AssertErrorsEqual(t, errors.New("an object with the name does-not-belong exists, but it doesn't appear to be a OperatorConfig"), err)
+	})
+
+	t.Run("transform", func(t *testing.T) {
+		err := secretsClient.Transform("default", "created-through-client", func(s *v1.Secret) error {
+			s.Labels["mutated"] = "true"
+			s.Labels["is-a"] = "try-to-overwrite"
+
+			return nil
+		})
+		testutil.AssertNil(t, "transform err", err)
+
+		modified, err := secretsClient.Get("default", "created-through-client")
+		testutil.AssertNil(t, "get err", err)
+
+		testutil.AssertEqual(t, "mutated label", "true", modified.Labels["mutated"])
+		testutil.AssertEqual(t, "is-a label", "OperatorConfig", modified.Labels["is-a"])
+	})
+}
+
+func TestClient_Delete(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Namespace string
+		Name      string
+		Options   []DeleteOption
+		ExpectErr error
+		Setup     func(mockK8s cv1.SecretsGetter)
+	}{
+		"secret does not exist": {
+			Namespace: "default",
+			Name:      "some-secret",
+			Options:   []DeleteOption{},
+			ExpectErr: errors.New(`couldn't delete the OperatorConfig with the name "some-secret": secrets "some-secret" not found`),
+		},
+		"secret exists": {
+			Namespace: "my-namespace",
+			Name:      "some-secret",
+			Options:   []DeleteOption{},
+			Setup: func(mockK8s cv1.SecretsGetter) {
+				secret := &v1.Secret{}
+				secret.Name = "some-secret"
+				mockK8s.Secrets("my-namespace").Create(secret)
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			mockK8s := testclient.NewSimpleClientset().CoreV1()
+			if tc.Setup != nil {
+				tc.Setup(mockK8s)
+			}
+
+			secretsClient := coreClient{
+				kclient: mockK8s,
+			}
+
+			actualErr := secretsClient.Delete(tc.Namespace, tc.Name, tc.Options...)
+			if tc.ExpectErr != nil || actualErr != nil {
+				testutil.AssertErrorsEqual(t, tc.ExpectErr, actualErr)
+
+				return
+			}
+
+			secrets, err := mockK8s.Secrets(tc.Namespace).List(metav1.ListOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, s := range secrets.Items {
+				if s.Name == tc.Name {
+					t.Fatal("The secret wasn't deleted")
+				}
+			}
+		})
+	}
+}

--- a/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
@@ -1,0 +1,261 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file was generated with functions.go, DO NOT EDIT IT.
+
+package gentest
+
+// Generator defined imports
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// User defined imports
+import (
+	v1 "k8s.io/api/core/v1"
+	cv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// Functional Utilities
+////////////////////////////////////////////////////////////////////////////////
+
+const (
+	// Kind contains the kind for the backing Kubernetes API.
+	Kind = "Secret"
+
+	// APIVersion contains the version for the backing Kubernetes API.
+	APIVersion = "v1"
+)
+
+// Predicate is a boolean function for a v1.Secret.
+type Predicate func(*v1.Secret) bool
+
+// AllPredicate is a predicate that passes if all children pass.
+func AllPredicate(children ...Predicate) Predicate {
+	return func(obj *v1.Secret) bool {
+		for _, filter := range children {
+			if !filter(obj) {
+				return false
+			}
+		}
+
+		return true
+	}
+}
+
+// Mutator is a function that changes v1.Secret.
+type Mutator func(*v1.Secret) error
+
+// List represents a collection of v1.Secret.
+type List []v1.Secret
+
+// Filter returns a new list items for which the predicates fails removed.
+func (list List) Filter(filter Predicate) (out List) {
+	for _, v := range list {
+		if filter(&v) {
+			out = append(out, v)
+		}
+	}
+
+	return
+}
+
+// MutatorList is a list of mutators.
+type MutatorList []Mutator
+
+// Apply passes the given value to each of the mutators in the list failing if
+// one of them returns an error.
+func (list MutatorList) Apply(svc *v1.Secret) error {
+	for _, mutator := range list {
+		if err := mutator(svc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// LabelSetMutator creates a mutator that sets the given labels on the object.
+func LabelSetMutator(labels map[string]string) Mutator {
+	return func(obj *v1.Secret) error {
+		if obj.Labels == nil {
+			obj.Labels = make(map[string]string)
+		}
+
+		for key, value := range labels {
+			obj.Labels[key] = value
+		}
+
+		return nil
+	}
+}
+
+// LabelEqualsPredicate validates that the given label exists exactly on the object.
+func LabelEqualsPredicate(key, value string) Predicate {
+	return func(obj *v1.Secret) bool {
+		return obj.Labels[key] == value
+	}
+}
+
+// LabelsContainsPredicate validates that the given label exists on the object.
+func LabelsContainsPredicate(key string) Predicate {
+	return func(obj *v1.Secret) bool {
+		_, ok := obj.Labels[key]
+		return ok
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Client
+////////////////////////////////////////////////////////////////////////////////
+
+// Client is the interface for interacting with v1.Secret types as OperatorConfig CF style objects.
+type Client interface {
+	Create(namespace string, obj *v1.Secret, opts ...CreateOption) (*v1.Secret, error)
+	Update(namespace string, obj *v1.Secret, opts ...UpdateOption) (*v1.Secret, error)
+	Transform(namespace string, name string, transformer Mutator) error
+	Get(namespace string, name string, opts ...GetOption) (*v1.Secret, error)
+	Delete(namespace string, name string, opts ...DeleteOption) error
+	List(namespace string, opts ...ListOption) ([]v1.Secret, error)
+
+	// ClientExtension can be used by the developer to extend the client.
+	ClientExtension
+}
+
+type coreClient struct {
+	kclient cv1.SecretsGetter
+
+	upsertMutate        MutatorList
+	membershipValidator Predicate
+}
+
+func (core *coreClient) preprocessUpsert(obj *v1.Secret) error {
+	if err := core.upsertMutate.Apply(obj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Create inserts the given v1.Secret into the cluster.
+// The value to be inserted will be preprocessed and validated before being sent.
+func (core *coreClient) Create(namespace string, obj *v1.Secret, opts ...CreateOption) (*v1.Secret, error) {
+	if err := core.preprocessUpsert(obj); err != nil {
+		return nil, err
+	}
+
+	return core.kclient.Secrets(namespace).Create(obj)
+}
+
+// Update replaces the existing object in the cluster with the new one.
+// The value to be inserted will be preprocessed and validated before being sent.
+func (core *coreClient) Update(namespace string, obj *v1.Secret, opts ...UpdateOption) (*v1.Secret, error) {
+	if err := core.preprocessUpsert(obj); err != nil {
+		return nil, err
+	}
+
+	return core.kclient.Secrets(namespace).Update(obj)
+}
+
+// Transform performs a read/modify/write on the object with the given name.
+// Transform manages the options for the Get and Update calls.
+func (core *coreClient) Transform(namespace string, name string, mutator Mutator) error {
+	obj, err := core.Get(namespace, name)
+	if err != nil {
+		return err
+	}
+
+	if err := mutator(obj); err != nil {
+		return err
+	}
+
+	if _, err := core.Update(namespace, obj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Get retrieves an existing object in the cluster with the given name.
+// The function will return an error if an object is retrieved from the cluster
+// but doesn't pass the membership test of this client.
+func (core *coreClient) Get(namespace string, name string, opts ...GetOption) (*v1.Secret, error) {
+	res, err := core.kclient.Secrets(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get the OperatorConfig with the name %q: %v", name, err)
+	}
+
+	if core.membershipValidator(res) {
+		return res, nil
+	}
+
+	return nil, fmt.Errorf("an object with the name %s exists, but it doesn't appear to be a OperatorConfig", name)
+}
+
+// Delete removes an existing object in the cluster.
+// The deleted object is NOT tested for membership before deletion.
+func (core *coreClient) Delete(namespace string, name string, opts ...DeleteOption) error {
+	cfg := DeleteOptionDefaults().Extend(opts).toConfig()
+
+	if err := core.kclient.Secrets(namespace).Delete(name, cfg.ToDeleteOptions()); err != nil {
+		return fmt.Errorf("couldn't delete the OperatorConfig with the name %q: %v", name, err)
+	}
+
+	return nil
+}
+
+func (cfg deleteConfig) ToDeleteOptions() *metav1.DeleteOptions {
+	resp := metav1.DeleteOptions{}
+
+	if cfg.ForegroundDeletion {
+		propigationPolicy := metav1.DeletePropagationForeground
+		resp.PropagationPolicy = &propigationPolicy
+	}
+
+	if cfg.DeleteImmediately {
+		resp.GracePeriodSeconds = new(int64)
+	}
+
+	return &resp
+}
+
+// List gets objects in the cluster and filters the results based on the
+// internal membership test.
+func (core *coreClient) List(namespace string, opts ...ListOption) ([]v1.Secret, error) {
+	cfg := ListOptionDefaults().Extend(opts).toConfig()
+
+	res, err := core.kclient.Secrets(namespace).List(cfg.ToListOptions())
+	if err != nil {
+		return nil, fmt.Errorf("couldn't list OperatorConfigs: %v", err)
+	}
+
+	return List(res.Items).
+		Filter(core.membershipValidator).
+		Filter(AllPredicate(cfg.filters...)), nil
+}
+
+func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
+	if cfg.fieldSelector != nil {
+		resp.FieldSelector = metav1.SetAsLabelSelector(cfg.fieldSelector).String()
+	}
+
+	if cfg.labelSelector != nil {
+		resp.LabelSelector = metav1.SetAsLabelSelector(cfg.labelSelector).String()
+	}
+
+	return
+}

--- a/pkg/kf/internal/tools/clientgen/gentest/zz_generated.clientoptions.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/zz_generated.clientoptions.go
@@ -1,0 +1,262 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file was generated with option-builder.go, DO NOT EDIT IT.
+
+package gentest
+
+type createConfig struct {
+}
+
+// CreateOption is a single option for configuring a createConfig
+type CreateOption func(*createConfig)
+
+// CreateOptions is a configuration set defining a createConfig
+type CreateOptions []CreateOption
+
+// toConfig applies all the options to a new createConfig and returns it.
+func (opts CreateOptions) toConfig() createConfig {
+	cfg := createConfig{}
+
+	for _, v := range opts {
+		v(&cfg)
+	}
+
+	return cfg
+}
+
+// Extend creates a new CreateOptions with the contents of other overriding
+// the values set in this CreateOptions.
+func (opts CreateOptions) Extend(other CreateOptions) CreateOptions {
+	var out CreateOptions
+	out = append(out, opts...)
+	out = append(out, other...)
+	return out
+}
+
+// CreateOptionDefaults gets the default values for Create.
+func CreateOptionDefaults() CreateOptions {
+	return CreateOptions{}
+}
+
+type updateConfig struct {
+}
+
+// UpdateOption is a single option for configuring a updateConfig
+type UpdateOption func(*updateConfig)
+
+// UpdateOptions is a configuration set defining a updateConfig
+type UpdateOptions []UpdateOption
+
+// toConfig applies all the options to a new updateConfig and returns it.
+func (opts UpdateOptions) toConfig() updateConfig {
+	cfg := updateConfig{}
+
+	for _, v := range opts {
+		v(&cfg)
+	}
+
+	return cfg
+}
+
+// Extend creates a new UpdateOptions with the contents of other overriding
+// the values set in this UpdateOptions.
+func (opts UpdateOptions) Extend(other UpdateOptions) UpdateOptions {
+	var out UpdateOptions
+	out = append(out, opts...)
+	out = append(out, other...)
+	return out
+}
+
+// UpdateOptionDefaults gets the default values for Update.
+func UpdateOptionDefaults() UpdateOptions {
+	return UpdateOptions{}
+}
+
+type getConfig struct {
+}
+
+// GetOption is a single option for configuring a getConfig
+type GetOption func(*getConfig)
+
+// GetOptions is a configuration set defining a getConfig
+type GetOptions []GetOption
+
+// toConfig applies all the options to a new getConfig and returns it.
+func (opts GetOptions) toConfig() getConfig {
+	cfg := getConfig{}
+
+	for _, v := range opts {
+		v(&cfg)
+	}
+
+	return cfg
+}
+
+// Extend creates a new GetOptions with the contents of other overriding
+// the values set in this GetOptions.
+func (opts GetOptions) Extend(other GetOptions) GetOptions {
+	var out GetOptions
+	out = append(out, opts...)
+	out = append(out, other...)
+	return out
+}
+
+// GetOptionDefaults gets the default values for Get.
+func GetOptionDefaults() GetOptions {
+	return GetOptions{}
+}
+
+type deleteConfig struct {
+	// DeleteImmediately is If the resource should be deleted immediately.
+	DeleteImmediately bool
+	// ForegroundDeletion is If the resource should be deleted in the foreground.
+	ForegroundDeletion bool
+}
+
+// DeleteOption is a single option for configuring a deleteConfig
+type DeleteOption func(*deleteConfig)
+
+// DeleteOptions is a configuration set defining a deleteConfig
+type DeleteOptions []DeleteOption
+
+// toConfig applies all the options to a new deleteConfig and returns it.
+func (opts DeleteOptions) toConfig() deleteConfig {
+	cfg := deleteConfig{}
+
+	for _, v := range opts {
+		v(&cfg)
+	}
+
+	return cfg
+}
+
+// Extend creates a new DeleteOptions with the contents of other overriding
+// the values set in this DeleteOptions.
+func (opts DeleteOptions) Extend(other DeleteOptions) DeleteOptions {
+	var out DeleteOptions
+	out = append(out, opts...)
+	out = append(out, other...)
+	return out
+}
+
+// DeleteImmediately returns the last set value for DeleteImmediately or the empty value
+// if not set.
+func (opts DeleteOptions) DeleteImmediately() bool {
+	return opts.toConfig().DeleteImmediately
+}
+
+// ForegroundDeletion returns the last set value for ForegroundDeletion or the empty value
+// if not set.
+func (opts DeleteOptions) ForegroundDeletion() bool {
+	return opts.toConfig().ForegroundDeletion
+}
+
+// WithDeleteDeleteImmediately creates an Option that sets If the resource should be deleted immediately.
+func WithDeleteDeleteImmediately(val bool) DeleteOption {
+	return func(cfg *deleteConfig) {
+		cfg.DeleteImmediately = val
+	}
+}
+
+// WithDeleteForegroundDeletion creates an Option that sets If the resource should be deleted in the foreground.
+func WithDeleteForegroundDeletion(val bool) DeleteOption {
+	return func(cfg *deleteConfig) {
+		cfg.ForegroundDeletion = val
+	}
+}
+
+// DeleteOptionDefaults gets the default values for Delete.
+func DeleteOptionDefaults() DeleteOptions {
+	return DeleteOptions{}
+}
+
+type listConfig struct {
+	// fieldSelector is A selector on the resource's fields.
+	fieldSelector map[string]string
+	// filters is Additional filters to apply.
+	filters []Predicate
+	// labelSelector is A label selector.
+	labelSelector map[string]string
+}
+
+// ListOption is a single option for configuring a listConfig
+type ListOption func(*listConfig)
+
+// ListOptions is a configuration set defining a listConfig
+type ListOptions []ListOption
+
+// toConfig applies all the options to a new listConfig and returns it.
+func (opts ListOptions) toConfig() listConfig {
+	cfg := listConfig{}
+
+	for _, v := range opts {
+		v(&cfg)
+	}
+
+	return cfg
+}
+
+// Extend creates a new ListOptions with the contents of other overriding
+// the values set in this ListOptions.
+func (opts ListOptions) Extend(other ListOptions) ListOptions {
+	var out ListOptions
+	out = append(out, opts...)
+	out = append(out, other...)
+	return out
+}
+
+// fieldSelector returns the last set value for fieldSelector or the empty value
+// if not set.
+func (opts ListOptions) fieldSelector() map[string]string {
+	return opts.toConfig().fieldSelector
+}
+
+// filters returns the last set value for filters or the empty value
+// if not set.
+func (opts ListOptions) filters() []Predicate {
+	return opts.toConfig().filters
+}
+
+// labelSelector returns the last set value for labelSelector or the empty value
+// if not set.
+func (opts ListOptions) labelSelector() map[string]string {
+	return opts.toConfig().labelSelector
+}
+
+// WithListfieldSelector creates an Option that sets A selector on the resource's fields.
+func WithListfieldSelector(val map[string]string) ListOption {
+	return func(cfg *listConfig) {
+		cfg.fieldSelector = val
+	}
+}
+
+// WithListfilters creates an Option that sets Additional filters to apply.
+func WithListfilters(val []Predicate) ListOption {
+	return func(cfg *listConfig) {
+		cfg.filters = val
+	}
+}
+
+// WithListlabelSelector creates an Option that sets A label selector.
+func WithListlabelSelector(val map[string]string) ListOption {
+	return func(cfg *listConfig) {
+		cfg.labelSelector = val
+	}
+}
+
+// ListOptionDefaults gets the default values for List.
+func ListOptionDefaults() ListOptions {
+	return ListOptions{}
+}

--- a/pkg/kf/internal/tools/clientgen/tmplclient.go
+++ b/pkg/kf/internal/tools/clientgen/tmplclient.go
@@ -1,0 +1,176 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientgen
+
+import (
+	"text/template"
+
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/internal/tools/generator"
+)
+
+var clientTemplate = template.Must(template.New("").Funcs(generator.TemplateFuncs()).Parse(`
+
+////////////////////////////////////////////////////////////////////////////////
+// Client
+////////////////////////////////////////////////////////////////////////////////
+
+{{ $nssig := "" }}
+{{ $ns := "" }}
+{{ $nsparam := "" }}
+
+{{ if .Kubernetes.Namespaced }}
+  {{ $nssig = "namespace string," }}
+  {{ $ns = "namespace" }}
+	{{ $nsparam = "namespace," }}
+{{ end }}
+
+// Client is the interface for interacting with {{.Type}} types as {{.CF.Name}} CF style objects.
+type Client interface {
+	Create({{ $nssig }} obj *{{.Type}}, opts ...CreateOption) (*{{.Type}}, error)
+	Update({{ $nssig }} obj *{{.Type}}, opts ...UpdateOption) (*{{.Type}}, error)
+	Transform({{ $nssig }} name string, transformer Mutator) error
+	Get({{ $nssig }} name string, opts ...GetOption) (*{{.Type}}, error)
+	Delete({{ $nssig }} name string, opts ...DeleteOption) error
+	List({{ $nssig }} opts ...ListOption) ([]{{.Type}}, error)
+
+	// ClientExtension can be used by the developer to extend the client.
+	ClientExtension
+}
+
+type coreClient struct {
+	kclient {{.ClientType}}
+
+	upsertMutate        MutatorList
+	membershipValidator Predicate
+}
+
+func (core *coreClient) preprocessUpsert(obj *{{.Type}}) error {
+	if err := core.upsertMutate.Apply(obj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Create inserts the given {{.Type}} into the cluster.
+// The value to be inserted will be preprocessed and validated before being sent.
+func (core *coreClient) Create({{ $nssig }} obj *{{.Type}}, opts ...CreateOption) (*{{.Type}}, error) {
+	if err := core.preprocessUpsert(obj); err != nil {
+		return nil, err
+	}
+
+	return core.kclient.{{ .Kubernetes.Plural }}({{ $ns }}).Create(obj)
+}
+
+// Update replaces the existing object in the cluster with the new one.
+// The value to be inserted will be preprocessed and validated before being sent.
+func (core *coreClient) Update({{ $nssig }} obj *{{.Type}}, opts ...UpdateOption) (*{{.Type}}, error) {
+	if err := core.preprocessUpsert(obj); err != nil {
+		return nil, err
+	}
+
+	return core.kclient.{{ .Kubernetes.Plural }}({{ $ns }}).Update(obj)
+}
+
+// Transform performs a read/modify/write on the object with the given name.
+// Transform manages the options for the Get and Update calls.
+func (core *coreClient) Transform({{ $nssig }} name string, mutator Mutator) error {
+	obj, err := core.Get({{ $nsparam }} name)
+	if err != nil {
+		return err
+	}
+
+	if err := mutator(obj); err != nil {
+		return err
+	}
+
+	if _, err := core.Update({{ $nsparam }} obj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Get retrieves an existing object in the cluster with the given name.
+// The function will return an error if an object is retrieved from the cluster
+// but doesn't pass the membership test of this client.
+func (core *coreClient) Get({{ $nssig }} name string, opts ...GetOption) (*{{.Type}}, error) {
+	res, err := core.kclient.{{ .Kubernetes.Plural }}({{ $ns }}).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get the {{.CF.Name}} with the name %q: %v", name, err)
+	}
+
+	if core.membershipValidator(res) {
+		return res, nil
+	}
+
+	return nil, fmt.Errorf("an object with the name %s exists, but it doesn't appear to be a {{.CF.Name}}", name)
+}
+
+// Delete removes an existing object in the cluster.
+// The deleted object is NOT tested for membership before deletion.
+func (core *coreClient) Delete({{ $nssig }} name string, opts ...DeleteOption) error {
+	cfg := DeleteOptionDefaults().Extend(opts).toConfig()
+
+	if err := core.kclient.{{ .Kubernetes.Plural }}({{ $ns }}).Delete(name, cfg.ToDeleteOptions()); err != nil {
+		return fmt.Errorf("couldn't delete the {{.CF.Name}} with the name %q: %v", name, err)
+	}
+
+	return nil
+}
+
+func (cfg deleteConfig) ToDeleteOptions() (*metav1.DeleteOptions) {
+	resp := metav1.DeleteOptions{}
+
+	if cfg.ForegroundDeletion {
+		propigationPolicy := metav1.DeletePropagationForeground
+		resp.PropagationPolicy = &propigationPolicy
+	}
+
+	if cfg.DeleteImmediately {
+		resp.GracePeriodSeconds = new(int64)
+	}
+
+	return &resp
+}
+
+// List gets objects in the cluster and filters the results based on the
+// internal membership test.
+func (core *coreClient) List({{ $nssig }} opts ...ListOption) ([]{{.Type}}, error) {
+  cfg := ListOptionDefaults().Extend(opts).toConfig()
+
+	res, err := core.kclient.{{ .Kubernetes.Plural }}({{ $ns }}).List(cfg.ToListOptions())
+	if err != nil {
+		return nil, fmt.Errorf("couldn't list {{.CF.Name}}s: %v", err)
+	}
+
+	return List(res.Items).
+		Filter(core.membershipValidator).
+		Filter(AllPredicate(cfg.filters...)), nil
+}
+
+func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
+	if cfg.fieldSelector != nil {
+		resp.FieldSelector = metav1.SetAsLabelSelector(cfg.fieldSelector).String()
+	}
+
+	if cfg.labelSelector != nil {
+		resp.LabelSelector = metav1.SetAsLabelSelector(cfg.labelSelector).String()
+	}
+
+	return
+}
+
+`))

--- a/pkg/kf/internal/tools/clientgen/tmplfunctional.go
+++ b/pkg/kf/internal/tools/clientgen/tmplfunctional.go
@@ -1,0 +1,114 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientgen
+
+import (
+	"text/template"
+
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/internal/tools/generator"
+)
+
+var functionalUtilTemplate = template.Must(template.New("").Funcs(generator.TemplateFuncs()).Parse(`
+
+////////////////////////////////////////////////////////////////////////////////
+// Functional Utilities
+////////////////////////////////////////////////////////////////////////////////
+
+const (
+	// Kind contains the kind for the backing Kubernetes API.
+	Kind = "{{.Kubernetes.Kind}}"
+
+	// APIVersion contains the version for the backing Kubernetes API.
+	APIVersion = "{{.Kubernetes.Version}}"
+)
+
+// Predicate is a boolean function for a {{.Type}}.
+type Predicate func(*{{.Type}}) bool
+
+// AllPredicate is a predicate that passes if all children pass.
+func AllPredicate(children ...Predicate) Predicate {
+	return func(obj *{{.Type}}) bool {
+		for _, filter := range children {
+			if !filter(obj) {
+				return false
+			}
+		}
+
+		return true
+	}
+}
+
+// Mutator is a function that changes {{.Type}}.
+type Mutator func(*{{.Type}}) error
+
+// List represents a collection of {{.Type}}.
+type List []{{.Type}}
+
+// Filter returns a new list items for which the predicates fails removed.
+func (list List) Filter(filter Predicate) (out List) {
+	for _, v := range list {
+		if filter(&v) {
+			out = append(out, v)
+		}
+	}
+
+	return
+}
+
+// MutatorList is a list of mutators.
+type MutatorList []Mutator
+
+// Apply passes the given value to each of the mutators in the list failing if
+// one of them returns an error.
+func (list MutatorList) Apply(svc *{{.Type}}) error {
+	for _, mutator := range list {
+		if err := mutator(svc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// LabelSetMutator creates a mutator that sets the given labels on the object.
+func LabelSetMutator(labels map[string]string) Mutator {
+	return func(obj *{{.Type}}) error {
+		if obj.Labels == nil {
+			obj.Labels = make(map[string]string)
+		}
+
+		for key, value := range labels {
+			obj.Labels[key] = value
+		}
+
+		return nil
+	}
+}
+
+// LabelEqualsPredicate validates that the given label exists exactly on the object.
+func LabelEqualsPredicate(key, value string) Predicate {
+	return func(obj *{{.Type}}) bool {
+		return obj.Labels[key] == value
+	}
+}
+
+// LabelsContainsPredicate validates that the given label exists on the object.
+func LabelsContainsPredicate(key string) Predicate {
+	return func(obj *{{.Type}}) bool {
+		_, ok := obj.Labels[key]
+		return ok
+	}
+}
+`))

--- a/pkg/kf/internal/tools/clientgen/tmplheader.go
+++ b/pkg/kf/internal/tools/clientgen/tmplheader.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientgen
+
+import (
+	"text/template"
+
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/internal/tools/generator"
+)
+
+var headerTemplate = template.Must(template.New("").Funcs(generator.TemplateFuncs()).Parse(`
+{{genlicense}}
+
+{{gennotice "functions.go"}}
+
+package {{.Package}}
+
+// Generator defined imports
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+
+// User defined imports
+{{genimports .Imports}}
+
+`))


### PR DESCRIPTION
This PR creates a client generator for `kf` that we can use to create clients for specific CF concepts. It follows the Kubernetes model for handling extensions and provides a way to run mutations and filters before writes and reads.

This filtering and automatic application means we can map multiple CF concepts to the same Kubernetes object model, apply defaults, and enforce inavariants on the created objects.

An example client is included to test the autogenerator and auto-generated code.