### PR TITLE
Initial manifest file support.

### DIFF
--- a/pkg/kf/commands/apps/push.go
+++ b/pkg/kf/commands/apps/push.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -76,15 +75,8 @@ func NewPushCommand(p *config.KfParams, pusher kf.Pusher, b SrcImageBuilder) *co
 				appName = args[0]
 			}
 
-			var err error
-			if path == "" {
-				path, err = os.Getwd()
-				if err != nil {
-					return err
-				}
-			}
-
 			// Kontext has to have a absolute path.
+			var err error
 			path, err = filepath.Abs(path)
 			if err != nil {
 				return err
@@ -157,10 +149,11 @@ func NewPushCommand(p *config.KfParams, pusher kf.Pusher, b SrcImageBuilder) *co
 		"The service account to enable access to the container registry",
 	)
 
-	pushCmd.Flags().StringVar(
+	pushCmd.Flags().StringVarP(
 		&path,
 		"path",
-		"",
+		"p",
+		".",
 		"The path the source code lives. Defaults to current directory.",
 	)
 

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -81,7 +81,6 @@ func TestPushCommand(t *testing.T) {
 			args:              []string{"app-name"},
 			containerRegistry: "some-reg.io",
 			serviceAccount:    "some-service-account",
-			path:              "some-path",
 			grpc:              true,
 			buildpack:         "some-buildpack",
 			envVars:           []string{"env1=val1", "env2=val2"},
@@ -94,7 +93,6 @@ func TestPushCommand(t *testing.T) {
 			pusherErr:         errors.New("some error"),
 			containerRegistry: "some-reg.io",
 			serviceAccount:    "some-service-account",
-			path:              "some-path",
 			wantImagePrefix:   "some-reg.io/src-app-name",
 		},
 		"container-registry is not provided": {
@@ -113,6 +111,12 @@ func TestPushCommand(t *testing.T) {
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
+
+			if tc.path != "" {
+				os.MkdirAll(tc.path, 0755)
+				defer os.RemoveAll(tc.path)
+			}
+
 			if tc.srcImageBuilder == nil {
 				tc.srcImageBuilder = func(dir, srcImage string) error { return nil }
 			}

--- a/pkg/kf/manifest/manifest.go
+++ b/pkg/kf/manifest/manifest.go
@@ -1,0 +1,100 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Application is a configuration for a single 12-factor-app.
+type Application struct {
+	Name string `yaml:"name,omitempty"`
+	Path string `yaml:"path,omitempty"`
+}
+
+// Manifest is an application's configuration.
+type Manifest struct {
+	Applications []Application `yaml:"applications"`
+}
+
+// NewFromFile creates a Manifest from a manifest file.
+func NewFromFile(manifestFile string) (*Manifest, error) {
+	reader, err := os.Open(manifestFile)
+	if err != nil {
+		return nil, err
+	}
+	return NewFromReader(reader)
+}
+
+// NewFromReader creates a Manifest from a reader.
+func NewFromReader(reader io.Reader) (*Manifest, error) {
+	bytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: validate manifest
+	m := Manifest{}
+	if err = yaml.Unmarshal(bytes, &m); err != nil {
+		return nil, err
+	}
+
+	return &m, nil
+}
+
+// NewFromFileOrDefault creates a Manifest from a file.
+// A backup appName can be provded if the given file does not exist.
+func NewFromFileOrDefault(manifestFile, appName string) (*Manifest, error) {
+	if manifestFile == "" && appName == "" {
+		return nil, errors.New("manifestFile and appName cannot both be empty")
+	}
+
+	if manifestFile != "" {
+		if _, err := os.Stat(manifestFile); err == nil {
+			return NewFromFile(manifestFile)
+		}
+
+		// Fall through to default Manifest
+	}
+
+	if appName == "" {
+		return nil, fmt.Errorf("manifest file %s did not exist. appName required", manifestFile)
+	}
+
+	return &Manifest{
+		Applications: []Application{
+			{
+				Name: appName,
+			},
+		},
+	}, nil
+}
+
+// App returns an Application by name.
+func (m Manifest) App(name string) (*Application, error) {
+	for _, app := range m.Applications {
+		if app.Name == name {
+			return &app, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no app %s found in the Manifest", name)
+}

--- a/pkg/kf/manifest/manifest_test.go
+++ b/pkg/kf/manifest/manifest_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/manifest"
 )
 
-func TestParse(t *testing.T) {
+func TestNewFromReader(t *testing.T) {
 
 	cases := map[string]struct {
 		fileContent string
@@ -50,7 +50,7 @@ applications:
 			if err != nil {
 				t.Error(err)
 			}
-			if !reflect.DeepEqual(actual, tc.expected) {
+			if !reflect.DeepEqual(*actual, tc.expected) {
 				t.Error(fmt.Printf("not equal: %v, %v", tc.expected, actual))
 			}
 		})

--- a/pkg/kf/manifest/manifest_test.go
+++ b/pkg/kf/manifest/manifest_test.go
@@ -1,0 +1,58 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/manifest"
+)
+
+func TestParse(t *testing.T) {
+
+	cases := map[string]struct {
+		fileContent string
+		expected    manifest.Manifest
+	}{
+		"app name": {
+			fileContent: `---
+applications:
+- name: MY-APP
+`,
+			expected: manifest.Manifest{
+				Applications: []manifest.Application{
+					manifest.Application{
+						Name: "MY-APP",
+					},
+				},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual, err := manifest.NewFromReader(strings.NewReader(tc.fileContent))
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Error(fmt.Printf("not equal: %v, %v", tc.expected, actual))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Only name and path fields currently implemented.
Required multiple apps per push to be supported.