### PR TITLE
pkg/kf: deployer injects env vars instead of push

### DIFF
--- a/pkg/kf/commands/wire_gen.go
+++ b/pkg/kf/commands/wire_gen.go
@@ -38,12 +38,12 @@ import (
 func InjectPush(p *config.KfParams) *cobra.Command {
 	servingV1alpha1Interface := config.GetServingClient(p)
 	appLister := kf.NewLister(servingV1alpha1Interface)
-	deployer := kf.NewDeployer(appLister, servingV1alpha1Interface)
+	systemEnvInjectorInterface := provideSystemEnvInjector(p)
+	deployer := kf.NewDeployer(appLister, servingV1alpha1Interface, systemEnvInjectorInterface)
 	buildV1alpha1Interface := config.GetBuildClient(p)
 	buildTailer := provideBuildTailer()
 	logs := kf.NewLogTailer(buildV1alpha1Interface, servingV1alpha1Interface, buildTailer)
-	systemEnvInjectorInterface := provideSystemEnvInjector(p)
-	pusher := kf.NewPusher(deployer, logs, systemEnvInjectorInterface)
+	pusher := kf.NewPusher(deployer, logs)
 	srcImageBuilder := provideSrcImageBuilder()
 	command := apps.NewPushCommand(p, pusher, srcImageBuilder)
 	return command

--- a/pkg/kf/push.go
+++ b/pkg/kf/push.go
@@ -34,10 +34,9 @@ import (
 
 // pusher deploys source code to Knative. It should be created via NewPusher.
 type pusher struct {
-	deployer    Deployer
-	bl          Logs
-	out         io.Writer
-	envInjector SystemEnvInjectorInterface
+	deployer Deployer
+	bl       Logs
+	out      io.Writer
 }
 
 // Logs handles build and deploy logs.
@@ -54,11 +53,10 @@ type Pusher interface {
 }
 
 // NewPusher creates a new Pusher.
-func NewPusher(d Deployer, bl Logs, sei SystemEnvInjectorInterface) Pusher {
+func NewPusher(d Deployer, bl Logs) Pusher {
 	return &pusher{
-		deployer:    d,
-		bl:          bl,
-		envInjector: sei,
+		deployer: d,
+		bl:       bl,
 	}
 }
 
@@ -101,10 +99,6 @@ func (p *pusher) Push(appName, srcImage string, opts ...PushOption) error {
 
 	if len(envs) > 0 {
 		s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Env = envs
-	}
-
-	if err := p.envInjector.InjectSystemEnv(&s); err != nil {
-		return err
 	}
 
 	resultingService, err := p.deployer.Deploy(s, WithDeployNamespace(cfg.Namespace))

--- a/pkg/kf/push_test.go
+++ b/pkg/kf/push_test.go
@@ -68,7 +68,6 @@ func TestPush_BadConfig(t *testing.T) {
 			p := kf.NewPusher(
 				nil, // Deployer - Should not be used
 				nil, // Logs - Should not be used
-				nil, // EnvInjector - Should not be used
 			)
 
 			gotErr := p.Push(tc.appName, tc.srcImage, tc.opts...)
@@ -124,13 +123,9 @@ func TestPush_Logs(t *testing.T) {
 				).
 				Return(tc.logErr)
 
-			fakeInjector := kffake.NewFakeSystemEnvInjector(ctrl)
-			fakeInjector.EXPECT().InjectSystemEnv(gomock.Any()).AnyTimes()
-
 			p := kf.NewPusher(
 				fakeDeployer,
 				fakeLogs,
-				fakeInjector,
 			)
 
 			gotErr := p.Push(
@@ -337,15 +332,11 @@ func TestPush(t *testing.T) {
 				Tail(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				AnyTimes()
 
-			fakeInjector := kffake.NewFakeSystemEnvInjector(ctrl)
-			fakeInjector.EXPECT().InjectSystemEnv(gomock.Any()).AnyTimes()
-
 			tc.setup(t, fakeDeployer)
 
 			p := kf.NewPusher(
 				fakeDeployer,
 				fakeLogs,
-				fakeInjector,
 			)
 
 			gotErr := p.Push(tc.appName, tc.srcImage, tc.opts...)


### PR DESCRIPTION
Previously, the role of injecting environment variables was left to
push. This CL moves the injecting to the Deployer.