### PR TITLE
pkg/kf/commands: fix usage display for built-in

### DIFF
--- a/pkg/kf/commands/root.go
+++ b/pkg/kf/commands/root.go
@@ -136,6 +136,10 @@ const (
 // earlier than pflags normally does.
 func builtIn() bool {
 	flags := pflag.NewFlagSet("built-in", pflag.ContinueOnError)
+	flags.Usage = func() {
+		// NOP - We don't want a --help to show anything for this FlagSet. The
+		// main FlagSet will take care of it.
+	}
 	result := flags.Bool(builtInLong, false, "")
 
 	// We are only configured to look for --built-in. So when we encounter


### PR DESCRIPTION
This CL prevents the help flag from displaying two sets of information
about the built-in flag. Previously, it would trigger the FlagSet that
is trying to decide if a built-in command should be used.

fixes #76