### PR TITLE
pkg/kf/commands/apps: adds buildpack integration test

### DIFF
--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -22,36 +22,28 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	. "github.com/GoogleCloudPlatform/kf/pkg/kf/testutil"
 )
 
-// TestIntegration_Doctor runs the doctor command. It ensures the cluster the
-// tests are running against is in good shape.
-func TestIntegration_Doctor(t *testing.T) {
-	t.Parallel()
-	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
-		kf.Doctor(ctx)
-	})
-}
-
 // TestIntegration_Push pushes the echo app (via --built-in command), lists it
 // to ensure it can find a domain, uses the proxy command and then posts to
 // it. It finally deletes the app.
 func TestIntegration_Push(t *testing.T) {
-	t.Parallel()
+	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		appName := fmt.Sprintf("integration-echo-%d", time.Now().UnixNano())
 
 		// Push an app and then clean it up. This pushes the echo app which
 		// replies with the same body that was posted.
-		kf.Push(ctx, appName, map[string]string{
-			"--built-in":           "",
-			"--path":               filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
-			"--container-registry": fmt.Sprintf("gcr.io/%s", GCPProjectID()),
-		})
+		kf.Push(ctx, appName,
+			"--built-in",
+			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
+			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+		)
 		defer kf.Delete(ctx, appName)
 
 		// List the apps and make sure we can find a domain.
@@ -86,17 +78,17 @@ func TestIntegration_Push(t *testing.T) {
 // TestIntegration_Delete pushes an app and then deletes it. It then makes
 // sure it is marked as "Deleting".
 func TestIntegration_Delete(t *testing.T) {
-	t.Parallel()
+	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		appName := fmt.Sprintf("integration-echo-%d", time.Now().UnixNano())
 
 		// Push an app and then clean it up. This pushes the echo app which
 		// simplies replies with the same body that was posted.
-		kf.Push(ctx, appName, map[string]string{
-			"--built-in":           "",
-			"--path":               filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
-			"--container-registry": fmt.Sprintf("gcr.io/%s", GCPProjectID()),
-		})
+		kf.Push(ctx, appName,
+			"--built-in",
+			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
+			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+		)
 
 		// This is only in place for cleanup if the test fails.
 		defer kf.Delete(ctx, appName)
@@ -123,7 +115,7 @@ func TestIntegration_Delete(t *testing.T) {
 // pushing, and another via SetEnv. It then reads them via Env. It then unsets
 // one via Unset and reads them again via Env.
 func TestIntegration_Envs(t *testing.T) {
-	t.Parallel()
+	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		appName := fmt.Sprintf("integration-envs-%d", time.Now().UnixNano())
 
@@ -196,13 +188,13 @@ func TestIntegration_Envs(t *testing.T) {
 		// Push an app and then clean it up. This pushes the envs app which
 		// returns the set environment variables via JSON. Set two environment
 		// variables (ENV1 and ENV2).
-		kf.Push(ctx, appName, map[string]string{
-			"--built-in":           "",
-			"--path":               filepath.Join(RootDir(ctx, t), "./samples/apps/envs"),
-			"--container-registry": fmt.Sprintf("gcr.io/%s", GCPProjectID()),
-			"--env":                "ENV1=VALUE1",
-			"--env=ENV2=VALUE2":    "",
-		})
+		kf.Push(ctx, appName,
+			"--built-in",
+			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/envs"),
+			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+			"--env", "ENV1=VALUE1",
+			"--env=ENV2=VALUE2",
+		)
 
 		// This is only in place for cleanup if the test fails.
 		defer kf.Delete(ctx, appName)
@@ -226,5 +218,43 @@ func TestIntegration_Envs(t *testing.T) {
 		checkVars(map[string]string{
 			"ENV2": "OVERWRITE2", // Set on push and overwritten via set-env
 		}, []string{"ENV1"})
+	})
+}
+
+var checkOnce sync.Once
+
+func checkClusterStatus(t *testing.T) {
+	checkOnce.Do(func() {
+		testIntegration_Buildpacks(t)
+		testIntegration_Doctor(t)
+	})
+}
+
+// testIntegration_Buildpacks uploads the sample buildpacks and then lists
+// them. It ensures the ablity to upload and list buildpacks along with
+// preparing the cluster for the rest of the integration tests (which require
+// the buildpacks).
+func testIntegration_Buildpacks(t *testing.T) {
+	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
+		kf.UploadBuildpacks(ctx,
+			"--path", filepath.Join(RootDir(ctx, t), "./samples/buildpacks"),
+			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+			"--built-in",
+		)
+
+		buildpacks := kf.Buildpacks(ctx)
+		AssertContainsAll(t, strings.Join(buildpacks, "\n"), []string{
+			"io.buildpacks.samples.nodejs",
+			"io.buildpacks.samples.go",
+			"io.buildpacks.samples.java",
+		})
+	})
+}
+
+// testIntegration_Doctor runs the doctor command. It ensures the cluster the
+// tests are running against is in good shape.
+func testIntegration_Doctor(t *testing.T) {
+	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
+		kf.Doctor(ctx)
 	})
 }


### PR DESCRIPTION
This CL adds a test that uploads the sample buildpacks via
`upload-buildpacks` and then ensures they are listed via `buildpacks`.

It also stops running the integration tests in parallel. This is for two
reasons:

1. Flakyness. While we should eventually be able to run these tests in
parallel, it currently doesn't work well.
2. Uploading the buildpacks is required to run before the rest of the
tests. Therefore, we want to make sure those run first.

fixes #96
fixes #79