### PR TITLE
Moved app listing to use the apps client.

### DIFF
--- a/pkg/kf/commands/apps/apps.go
+++ b/pkg/kf/commands/apps/apps.go
@@ -18,13 +18,13 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	"github.com/GoogleCloudPlatform/kf/pkg/kf"
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/apps"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/commands/config"
 	"github.com/spf13/cobra"
 )
 
 // NewAppsCommand creates a apps command.
-func NewAppsCommand(p *config.KfParams, l kf.AppLister) *cobra.Command {
+func NewAppsCommand(p *config.KfParams, appsClient apps.Client) *cobra.Command {
 	var apps = &cobra.Command{
 		Use:     "apps",
 		Short:   "List pushed apps",
@@ -33,7 +33,7 @@ func NewAppsCommand(p *config.KfParams, l kf.AppLister) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(p.Output, "Getting apps in namespace: %s\n", p.Namespace)
 
-			apps, err := l.List(kf.WithListNamespace(p.Namespace))
+			apps, err := appsClient.List(p.Namespace)
 			if err != nil {
 				return err
 			}

--- a/pkg/kf/commands/apps/apps_test.go
+++ b/pkg/kf/commands/apps/apps_test.go
@@ -20,9 +20,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/kf/pkg/kf"
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/apps/fake"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/commands/config"
-	"github.com/GoogleCloudPlatform/kf/pkg/kf/fake"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/testutil"
 	"github.com/golang/mock/gomock"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
@@ -36,7 +35,7 @@ func TestAppsCommand(t *testing.T) {
 		namespace string
 		wantErr   error
 		args      []string
-		setup     func(t *testing.T, fakeLister *fake.FakeLister)
+		setup     func(t *testing.T, fakeLister *fake.FakeClient)
 		assert    func(t *testing.T, buffer *bytes.Buffer)
 	}{
 		"invalid number of args": {
@@ -45,17 +44,14 @@ func TestAppsCommand(t *testing.T) {
 		},
 		"configured namespace": {
 			namespace: "some-namespace",
-			setup: func(t *testing.T, fakeLister *fake.FakeLister) {
+			setup: func(t *testing.T, fakeLister *fake.FakeClient) {
 				fakeLister.
 					EXPECT().
-					List(gomock.Any()).
-					Do(func(opts ...kf.ListOption) {
-						testutil.AssertEqual(t, "namespace", "some-namespace", kf.ListOptions(opts).Namespace())
-					})
+					List("some-namespace")
 			},
 		},
 		"formats multiple services": {
-			setup: func(t *testing.T, fakeLister *fake.FakeLister) {
+			setup: func(t *testing.T, fakeLister *fake.FakeClient) {
 				fakeLister.
 					EXPECT().
 					List(gomock.Any()).
@@ -71,7 +67,7 @@ func TestAppsCommand(t *testing.T) {
 			},
 		},
 		"shows app as deleting": {
-			setup: func(t *testing.T, fakeLister *fake.FakeLister) {
+			setup: func(t *testing.T, fakeLister *fake.FakeClient) {
 				fakeLister.
 					EXPECT().
 					List(gomock.Any()).
@@ -87,7 +83,7 @@ func TestAppsCommand(t *testing.T) {
 		},
 		"list applications error, returns error": {
 			wantErr: errors.New("some-error"),
-			setup: func(t *testing.T, fakeLister *fake.FakeLister) {
+			setup: func(t *testing.T, fakeLister *fake.FakeClient) {
 				fakeLister.
 					EXPECT().
 					List(gomock.Any()).
@@ -95,7 +91,7 @@ func TestAppsCommand(t *testing.T) {
 			},
 		},
 		"filters out configurations without a name": {
-			setup: func(t *testing.T, fakeLister *fake.FakeLister) {
+			setup: func(t *testing.T, fakeLister *fake.FakeClient) {
 				fakeLister.
 					EXPECT().
 					List(gomock.Any()).
@@ -113,7 +109,7 @@ func TestAppsCommand(t *testing.T) {
 	} {
 		t.Run(tn, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			fakeLister := fake.NewFakeLister(ctrl)
+			fakeLister := fake.NewFakeClient(ctrl)
 
 			if tc.setup != nil {
 				tc.setup(t, fakeLister)

--- a/pkg/kf/commands/wire_gen.go
+++ b/pkg/kf/commands/wire_gen.go
@@ -65,8 +65,9 @@ func InjectDelete(p *config.KfParams) *cobra.Command {
 
 func InjectApps(p *config.KfParams) *cobra.Command {
 	servingV1alpha1Interface := config.GetServingClient(p)
-	appLister := kf.NewLister(servingV1alpha1Interface)
-	command := apps.NewAppsCommand(p, appLister)
+	systemEnvInjectorInterface := provideSystemEnvInjector(p)
+	client := apps2.NewClient(servingV1alpha1Interface, systemEnvInjectorInterface)
+	command := apps.NewAppsCommand(p, client)
 	return command
 }
 

--- a/pkg/kf/commands/wire_injector.go
+++ b/pkg/kf/commands/wire_injector.go
@@ -81,15 +81,14 @@ func InjectPush(p *config.KfParams) *cobra.Command {
 }
 
 func InjectDelete(p *config.KfParams) *cobra.Command {
-	wire.Build(
-		capps.NewDeleteCommand,
-		AppsSet,
-	)
+	wire.Build(capps.NewDeleteCommand, AppsSet)
+
 	return nil
 }
 
 func InjectApps(p *config.KfParams) *cobra.Command {
-	wire.Build(capps.NewAppsCommand, kf.NewLister, config.GetServingClient)
+	wire.Build(capps.NewAppsCommand, AppsSet)
+
 	return nil
 }
 


### PR DESCRIPTION
Integration tests pass locally. After this is merged the only
thing still using the AppLister will be deploy.go.