### PR TITLE
pkg/kf: renames LogTailer.Tail to DeployLogs

### DIFF
--- a/pkg/kf/fake/fake_log_tailer.go
+++ b/pkg/kf/fake/fake_log_tailer.go
@@ -48,16 +48,16 @@ func (m *FakeLogTailer) EXPECT() *FakeLogTailerMockRecorder {
 	return m.recorder
 }
 
-// Tail mocks base method
-func (m *FakeLogTailer) Tail(arg0 io.Writer, arg1, arg2, arg3 string) error {
+// DeployLogs mocks base method
+func (m *FakeLogTailer) DeployLogs(arg0 io.Writer, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Tail", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "DeployLogs", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Tail indicates an expected call of Tail
-func (mr *FakeLogTailerMockRecorder) Tail(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// DeployLogs indicates an expected call of DeployLogs
+func (mr *FakeLogTailerMockRecorder) DeployLogs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tail", reflect.TypeOf((*FakeLogTailer)(nil).Tail), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployLogs", reflect.TypeOf((*FakeLogTailer)(nil).DeployLogs), arg0, arg1, arg2, arg3)
 }

--- a/pkg/kf/log_tailer.go
+++ b/pkg/kf/log_tailer.go
@@ -28,6 +28,13 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
+// Logs handles build and deploy logs.
+type Logs interface {
+	// DeployLogs writes the logs for the build and deploy stage to the given
+	// out.  The method exits once the logs are done streaming.
+	DeployLogs(out io.Writer, appName, resourceVersion, namespace string) error
+}
+
 // BuildTailer writes the build logs to out.
 type BuildTailer interface {
 	Tail(ctx context.Context, out io.Writer, buildName, namespace string) error
@@ -62,9 +69,9 @@ func NewLogTailer(
 	}
 }
 
-// Tail writes the logs for the build and deploy step for the resourceVersion
+// DeployLogs writes the logs for the build and deploy step for the resourceVersion
 // to out. It blocks until the operation has completed.
-func (t logTailer) Tail(out io.Writer, appName, resourceVersion, namespace string) error {
+func (t logTailer) DeployLogs(out io.Writer, appName, resourceVersion, namespace string) error {
 	errs := make(chan error, 2)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/kf/log_tailer_test.go
+++ b/pkg/kf/log_tailer_test.go
@@ -37,7 +37,7 @@ import (
 
 //go:generate mockgen --package kf_test --destination fake_watcher_test.go --mock_names=Interface=FakeWatcher --copyright_file internal/tools/option-builder/LICENSE_HEADER k8s.io/apimachinery/pkg/watch Interface
 
-func TestLogTailer_ServiceLogs(t *testing.T) {
+func TestLogTailer_DeployLogs_ServiceLogs(t *testing.T) {
 	t.Parallel()
 
 	for tn, tc := range map[string]struct {
@@ -100,7 +100,7 @@ func TestLogTailer_ServiceLogs(t *testing.T) {
 			)
 
 			var buffer bytes.Buffer
-			gotErr := lt.Tail(&buffer, tc.appName, tc.resourceVersion, tc.namespace)
+			gotErr := lt.DeployLogs(&buffer, tc.appName, tc.resourceVersion, tc.namespace)
 			if tc.wantErr != nil || gotErr != nil {
 				testutil.AssertErrorsEqual(t, tc.wantErr, gotErr)
 				return
@@ -123,7 +123,7 @@ func TestLogTailer_ServiceLogs(t *testing.T) {
 	}
 }
 
-func TestLogTailer_BuildLogs(t *testing.T) {
+func TestLogTailer_DeployLogs_BuildLogs(t *testing.T) {
 	t.Parallel()
 
 	for tn, tc := range map[string]struct {
@@ -232,7 +232,7 @@ func TestLogTailer_BuildLogs(t *testing.T) {
 				tc.tailF(t),
 			)
 
-			gotErr := lt.Tail(&buffer, tc.appName, tc.resourceVersion, tc.namespace)
+			gotErr := lt.DeployLogs(&buffer, tc.appName, tc.resourceVersion, tc.namespace)
 			if tc.wantErr != nil || gotErr != nil {
 				testutil.AssertErrorsEqual(t, tc.wantErr, gotErr)
 				return

--- a/pkg/kf/push.go
+++ b/pkg/kf/push.go
@@ -39,13 +39,6 @@ type pusher struct {
 	out      io.Writer
 }
 
-// Logs handles build and deploy logs.
-type Logs interface {
-	// Tail writes the logs for the build and deploy stage to the given out.
-	// The method exits once the logs are done streaming.
-	Tail(out io.Writer, appName, resourceVersion, namespace string) error
-}
-
 // Pusher deploys applications.
 type Pusher interface {
 	// Push deploys an application.
@@ -106,7 +99,7 @@ func (p *pusher) Push(appName, srcImage string, opts ...PushOption) error {
 		return fmt.Errorf("failed to deploy: %s", err)
 	}
 
-	if err := p.bl.Tail(cfg.Output, appName, resultingService.ResourceVersion, cfg.Namespace); err != nil {
+	if err := p.bl.DeployLogs(cfg.Output, appName, resultingService.ResourceVersion, cfg.Namespace); err != nil {
 		return err
 	}
 

--- a/pkg/kf/push_test.go
+++ b/pkg/kf/push_test.go
@@ -115,7 +115,7 @@ func TestPush_Logs(t *testing.T) {
 
 			fakeLogs := kffake.NewFakeLogTailer(ctrl)
 			fakeLogs.EXPECT().
-				Tail(
+				DeployLogs(
 					gomock.Not(gomock.Nil()), // out,
 					tc.appName,               // appName
 					tc.appName+"-version",    // resourceVersion
@@ -330,7 +330,7 @@ func TestPush(t *testing.T) {
 
 			fakeLogs := kffake.NewFakeLogTailer(ctrl)
 			fakeLogs.EXPECT().
-				Tail(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DeployLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				AnyTimes()
 
 			tc.setup(t, fakeDeployer)


### PR DESCRIPTION
This paves the way for a separate method that tails the logs of an
application instead of the logs that are egressed during deployment.