### PR TITLE
Added the ability to upsert values.

### DIFF
--- a/pkg/kf/apps/fake/fake_client.go
+++ b/pkg/kf/apps/fake/fake_client.go
@@ -175,3 +175,18 @@ func (mr *FakeClientMockRecorder) Update(arg0, arg1 interface{}, arg2 ...interfa
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*FakeClient)(nil).Update), varargs...)
 }
+
+// Upsert mocks base method
+func (m *FakeClient) Upsert(arg0 string, arg1 *v1alpha1.Service, arg2 apps.Merger) (*v1alpha1.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Upsert", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*v1alpha1.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Upsert indicates an expected call of Upsert
+func (mr *FakeClientMockRecorder) Upsert(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*FakeClient)(nil).Upsert), arg0, arg1, arg2)
+}

--- a/pkg/kf/apps/zz_generated.client.go
+++ b/pkg/kf/apps/zz_generated.client.go
@@ -131,6 +131,7 @@ type Client interface {
 	Get(namespace string, name string, opts ...GetOption) (*serving.Service, error)
 	Delete(namespace string, name string, opts ...DeleteOption) error
 	List(namespace string, opts ...ListOption) ([]serving.Service, error)
+	Upsert(namespace string, newObj *serving.Service, merge Merger) (*serving.Service, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -250,12 +251,34 @@ func (core *coreClient) List(namespace string, opts ...ListOption) ([]serving.Se
 
 func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 	if cfg.fieldSelector != nil {
-		resp.FieldSelector = metav1.SetAsLabelSelector(cfg.fieldSelector).String()
+		resp.FieldSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.fieldSelector))
 	}
 
 	if cfg.labelSelector != nil {
-		resp.LabelSelector = metav1.SetAsLabelSelector(cfg.labelSelector).String()
+		resp.LabelSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.labelSelector))
 	}
 
 	return
+}
+
+// Merger is a type to merge an existing value with a new one.
+type Merger func(newObj, oldObj *serving.Service) *serving.Service
+
+// Upsert inerts the object into the cluster if it doesn't already exist, or else
+// calls the merge function to merge the existing and new then performs an Update.
+func (core *coreClient) Upsert(namespace string, newObj *serving.Service, merge Merger) (*serving.Service, error) {
+	// NOTE: the field selector may be ignored by some Kubernetes resources
+	// so we double check down below.
+	existing, err := core.List(namespace, WithListfieldSelector(map[string]string{"metadata.name": newObj.Name}))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, oldObj := range existing {
+		if oldObj.Name == newObj.Name {
+			return core.Update(namespace, merge(newObj, &oldObj))
+		}
+	}
+
+	return core.Create(namespace, newObj)
 }

--- a/pkg/kf/apps/zz_generated.client.go
+++ b/pkg/kf/apps/zz_generated.client.go
@@ -264,7 +264,7 @@ func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 // Merger is a type to merge an existing value with a new one.
 type Merger func(newObj, oldObj *serving.Service) *serving.Service
 
-// Upsert inerts the object into the cluster if it doesn't already exist, or else
+// Upsert inserts the object into the cluster if it doesn't already exist, or else
 // calls the merge function to merge the existing and new then performs an Update.
 func (core *coreClient) Upsert(namespace string, newObj *serving.Service, merge Merger) (*serving.Service, error) {
 	// NOTE: the field selector may be ignored by some Kubernetes resources

--- a/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
@@ -264,7 +264,7 @@ func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 // Merger is a type to merge an existing value with a new one.
 type Merger func(newObj, oldObj *v1.Secret) *v1.Secret
 
-// Upsert inerts the object into the cluster if it doesn't already exist, or else
+// Upsert inserts the object into the cluster if it doesn't already exist, or else
 // calls the merge function to merge the existing and new then performs an Update.
 func (core *coreClient) Upsert(namespace string, newObj *v1.Secret, merge Merger) (*v1.Secret, error) {
 	// NOTE: the field selector may be ignored by some Kubernetes resources

--- a/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
@@ -131,6 +131,7 @@ type Client interface {
 	Get(namespace string, name string, opts ...GetOption) (*v1.Secret, error)
 	Delete(namespace string, name string, opts ...DeleteOption) error
 	List(namespace string, opts ...ListOption) ([]v1.Secret, error)
+	Upsert(namespace string, newObj *v1.Secret, merge Merger) (*v1.Secret, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -250,12 +251,34 @@ func (core *coreClient) List(namespace string, opts ...ListOption) ([]v1.Secret,
 
 func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 	if cfg.fieldSelector != nil {
-		resp.FieldSelector = metav1.SetAsLabelSelector(cfg.fieldSelector).String()
+		resp.FieldSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.fieldSelector))
 	}
 
 	if cfg.labelSelector != nil {
-		resp.LabelSelector = metav1.SetAsLabelSelector(cfg.labelSelector).String()
+		resp.LabelSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.labelSelector))
 	}
 
 	return
+}
+
+// Merger is a type to merge an existing value with a new one.
+type Merger func(newObj, oldObj *v1.Secret) *v1.Secret
+
+// Upsert inerts the object into the cluster if it doesn't already exist, or else
+// calls the merge function to merge the existing and new then performs an Update.
+func (core *coreClient) Upsert(namespace string, newObj *v1.Secret, merge Merger) (*v1.Secret, error) {
+	// NOTE: the field selector may be ignored by some Kubernetes resources
+	// so we double check down below.
+	existing, err := core.List(namespace, WithListfieldSelector(map[string]string{"metadata.name": newObj.Name}))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, oldObj := range existing {
+		if oldObj.Name == newObj.Name {
+			return core.Update(namespace, merge(newObj, &oldObj))
+		}
+	}
+
+	return core.Create(namespace, newObj)
 }

--- a/pkg/kf/internal/tools/clientgen/tmplclient.go
+++ b/pkg/kf/internal/tools/clientgen/tmplclient.go
@@ -44,6 +44,7 @@ type Client interface {
 	Get({{ $nssig }} name string, opts ...GetOption) (*{{.Type}}, error)
 	Delete({{ $nssig }} name string, opts ...DeleteOption) error
 	List({{ $nssig }} opts ...ListOption) ([]{{.Type}}, error)
+	Upsert({{ $nssig }} newObj *{{.Type}}, merge Merger) (*{{.Type}}, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -163,14 +164,36 @@ func (core *coreClient) List({{ $nssig }} opts ...ListOption) ([]{{.Type}}, erro
 
 func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 	if cfg.fieldSelector != nil {
-		resp.FieldSelector = metav1.SetAsLabelSelector(cfg.fieldSelector).String()
+		resp.FieldSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.fieldSelector))
 	}
 
 	if cfg.labelSelector != nil {
-		resp.LabelSelector = metav1.SetAsLabelSelector(cfg.labelSelector).String()
+		resp.LabelSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.labelSelector))
 	}
 
 	return
 }
 
+
+// Merger is a type to merge an existing value with a new one.
+type Merger func(newObj, oldObj *{{.Type}}) *{{.Type}}
+
+// Upsert inerts the object into the cluster if it doesn't already exist, or else
+// calls the merge function to merge the existing and new then performs an Update.
+func (core *coreClient) Upsert({{ $nssig }} newObj *{{.Type}}, merge Merger) (*{{.Type}}, error) {
+	// NOTE: the field selector may be ignored by some Kubernetes resources
+	// so we double check down below.
+	existing, err := core.List({{ $nsparam }} WithListfieldSelector(map[string]string{"metadata.name": newObj.Name}))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, oldObj := range existing {
+		if oldObj.Name == newObj.Name {
+			return core.Update({{ $nsparam }} merge(newObj, &oldObj))
+		}
+	}
+
+	return core.Create({{ $nsparam }} newObj)
+}
 `))

--- a/pkg/kf/internal/tools/clientgen/tmplclient.go
+++ b/pkg/kf/internal/tools/clientgen/tmplclient.go
@@ -178,7 +178,7 @@ func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 // Merger is a type to merge an existing value with a new one.
 type Merger func(newObj, oldObj *{{.Type}}) *{{.Type}}
 
-// Upsert inerts the object into the cluster if it doesn't already exist, or else
+// Upsert inserts the object into the cluster if it doesn't already exist, or else
 // calls the merge function to merge the existing and new then performs an Update.
 func (core *coreClient) Upsert({{ $nssig }} newObj *{{.Type}}, merge Merger) (*{{.Type}}, error) {
 	// NOTE: the field selector may be ignored by some Kubernetes resources

--- a/pkg/kf/spaces/fake/fake_client.go
+++ b/pkg/kf/spaces/fake/fake_client.go
@@ -160,3 +160,18 @@ func (mr *FakeClientMockRecorder) Update(arg0 interface{}, arg1 ...interface{}) 
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*FakeClient)(nil).Update), varargs...)
 }
+
+// Upsert mocks base method
+func (m *FakeClient) Upsert(arg0 *v1.Namespace, arg1 spaces.Merger) (*v1.Namespace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Upsert", arg0, arg1)
+	ret0, _ := ret[0].(*v1.Namespace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Upsert indicates an expected call of Upsert
+func (mr *FakeClientMockRecorder) Upsert(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*FakeClient)(nil).Upsert), arg0, arg1)
+}

--- a/pkg/kf/spaces/zz_generated.client.go
+++ b/pkg/kf/spaces/zz_generated.client.go
@@ -264,7 +264,7 @@ func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 // Merger is a type to merge an existing value with a new one.
 type Merger func(newObj, oldObj *v1.Namespace) *v1.Namespace
 
-// Upsert inerts the object into the cluster if it doesn't already exist, or else
+// Upsert inserts the object into the cluster if it doesn't already exist, or else
 // calls the merge function to merge the existing and new then performs an Update.
 func (core *coreClient) Upsert(newObj *v1.Namespace, merge Merger) (*v1.Namespace, error) {
 	// NOTE: the field selector may be ignored by some Kubernetes resources


### PR DESCRIPTION
This adds an upsert ability to generated clients. It does this by
listing the values on the cluster to see if any match the one with the
given name then merging and updating if that's the case otherwise
creating.

We can't use clever apimachinery functions to check error responses
because some of our upstream clients still use vendoring so the types
won't match.

There's also a bug fix for filtering based on labels and fieldselectors.