### PR TITLE
pkg/kf/commands/apps: fix manifest integration test

### DIFF
--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -96,6 +96,7 @@ func TestIntegration_Push_manifest(t *testing.T) {
 
 		// Push an app with a manifest file.
 		kf.Push(ctx, appName,
+			"--built-in",
 			"--path", appPath,
 			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
 			"--manifest", newManifestFile,


### PR DESCRIPTION
Adds --built-in flag to manifest test. This is required if a plugin is
overriding the Push command.