### PR TITLE
pkg/kf/commands: removes KfParams.Output

### DIFF
--- a/pkg/kf/commands/apps/apps.go
+++ b/pkg/kf/commands/apps/apps.go
@@ -31,18 +31,18 @@ func NewAppsCommand(p *config.KfParams, appsClient apps.Client) *cobra.Command {
 		Example: `  kf apps`,
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintf(p.Output, "Getting apps in namespace: %s\n", p.Namespace)
+			fmt.Fprintf(cmd.OutOrStdout(), "Getting apps in namespace: %s\n", p.Namespace)
 
 			apps, err := appsClient.List(p.Namespace)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(p.Output, "Found %d apps in namespace %s\n", len(apps), p.Namespace)
-			fmt.Fprintln(p.Output)
+			fmt.Fprintf(cmd.OutOrStdout(), "Found %d apps in namespace %s\n", len(apps), p.Namespace)
+			fmt.Fprintln(cmd.OutOrStdout())
 
 			// Emulating:
 			// https://github.com/knative/serving/blob/master/config/300-service.yaml
-			w := tabwriter.NewWriter(p.Output, 8, 4, 1, ' ', tabwriter.StripEscape)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 8, 4, 1, ' ', tabwriter.StripEscape)
 			fmt.Fprintln(w, "NAME\tDOMAIN\tLATEST CREATED\tLATEST READY\tREADY\tREASON")
 			for _, app := range apps {
 				status := ""

--- a/pkg/kf/commands/apps/apps_test.go
+++ b/pkg/kf/commands/apps/apps_test.go
@@ -119,7 +119,6 @@ func TestAppsCommand(t *testing.T) {
 
 			c := NewAppsCommand(&config.KfParams{
 				Namespace: tc.namespace,
-				Output:    buffer,
 			}, fakeLister)
 			c.SetOutput(buffer)
 

--- a/pkg/kf/commands/apps/delete_test.go
+++ b/pkg/kf/commands/apps/delete_test.go
@@ -66,8 +66,8 @@ func TestDeleteCommand(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			c := NewDeleteCommand(&config.KfParams{
 				Namespace: tc.namespace,
-				Output:    buffer,
 			}, fakeDeleter)
+			c.SetOutput(buffer)
 
 			gotErr := c.RunE(c, []string{tc.appName})
 			if tc.wantErr != nil || gotErr != nil {

--- a/pkg/kf/commands/apps/env.go
+++ b/pkg/kf/commands/apps/env.go
@@ -42,7 +42,7 @@ func NewEnvCommand(p *config.KfParams, appClient apps.Client) *cobra.Command {
 
 			kfapp := (*apps.KfApp)(app)
 
-			w := tabwriter.NewWriter(p.Output, 8, 4, 1, ' ', tabwriter.StripEscape)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 8, 4, 1, ' ', tabwriter.StripEscape)
 			fmt.Fprintln(w, "NAME\tVALUE")
 			for _, env := range kfapp.GetEnvVars() {
 				fmt.Fprintf(w, "%s\t%s\n", env.Name, env.Value)

--- a/pkg/kf/commands/apps/env_test.go
+++ b/pkg/kf/commands/apps/env_test.go
@@ -90,7 +90,6 @@ func TestEnvCommand(t *testing.T) {
 
 			buf := new(bytes.Buffer)
 			p := &config.KfParams{
-				Output:    buf,
 				Namespace: tc.Namespace,
 			}
 

--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -84,7 +84,6 @@ func TestIntegration_Push(t *testing.T) {
 // file. The app is identical to the echo app, and this fact is used to also
 // test manifest file environment variables. It finally deletes the app.
 func TestIntegration_Push_manifest(t *testing.T) {
-	t.Parallel()
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		currentTime := time.Now().UnixNano()
 		appName := fmt.Sprintf("integration-manifest-%d", currentTime)

--- a/pkg/kf/commands/apps/proxy.go
+++ b/pkg/kf/commands/apps/proxy.go
@@ -53,7 +53,7 @@ func NewProxyCommand(p *config.KfParams, appsClient apps.Client, ingressLister k
 			cmd.SilenceUsage = true
 
 			if gateway == "" {
-				fmt.Fprintln(p.Output, "Autodetecting app gateway. Specify a custom gateway using the --gateway flag.")
+				fmt.Fprintln(cmd.OutOrStdout(), "Autodetecting app gateway. Specify a custom gateway using the --gateway flag.")
 
 				ingress, err := kf.ExtractIngressFromList(ingressLister.ListIngresses())
 				if err != nil {
@@ -72,14 +72,14 @@ func NewProxyCommand(p *config.KfParams, appsClient apps.Client, ingressLister k
 				return err
 			}
 
-			fmt.Fprintf(p.Output, "Forwarding requests from http://%s to http://%s\n", listener.Addr(), gateway)
+			fmt.Fprintf(cmd.OutOrStdout(), "Forwarding requests from http://%s to http://%s\n", listener.Addr(), gateway)
 
 			if noStart {
-				fmt.Fprintln(p.Output, "exiting because no-start flag was provided")
+				fmt.Fprintln(cmd.OutOrStdout(), "exiting because no-start flag was provided")
 				return nil
 			}
 
-			return http.Serve(listener, createProxy(p.Output, app.Status.Domain, gateway))
+			return http.Serve(listener, createProxy(cmd.OutOrStdout(), app.Status.Domain, gateway))
 		},
 	}
 

--- a/pkg/kf/commands/apps/proxy_test.go
+++ b/pkg/kf/commands/apps/proxy_test.go
@@ -75,7 +75,6 @@ func TestNewProxyCommand(t *testing.T) {
 
 			buf := new(bytes.Buffer)
 			p := &config.KfParams{
-				Output:    buf,
 				Namespace: tc.Namespace,
 			}
 

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -152,15 +152,14 @@ func TestPushCommand(t *testing.T) {
 					return tc.pusherErr
 				})
 
-			buffer := &bytes.Buffer{}
-
 			c := NewPushCommand(&config.KfParams{
 				Namespace: tc.namespace,
-				Output:    buffer,
 			},
 				fakePusher,
 				tc.srcImageBuilder,
 			)
+			buffer := &bytes.Buffer{}
+			c.SetOutput(buffer)
 
 			c.Flags().Set("container-registry", tc.containerRegistry)
 			c.Flags().Set("service-account", tc.serviceAccount)

--- a/pkg/kf/commands/apps/set_env_test.go
+++ b/pkg/kf/commands/apps/set_env_test.go
@@ -81,7 +81,6 @@ func TestSetEnvCommand(t *testing.T) {
 
 			buf := new(bytes.Buffer)
 			p := &config.KfParams{
-				Output:    buf,
 				Namespace: tc.Namespace,
 			}
 

--- a/pkg/kf/commands/apps/unset_env_test.go
+++ b/pkg/kf/commands/apps/unset_env_test.go
@@ -83,7 +83,6 @@ func TestUnsetEnvCommand(t *testing.T) {
 
 			buf := new(bytes.Buffer)
 			p := &config.KfParams{
-				Output:    buf,
 				Namespace: tc.Namespace,
 			}
 

--- a/pkg/kf/commands/buildpacks/buildpacks.go
+++ b/pkg/kf/commands/buildpacks/buildpacks.go
@@ -41,7 +41,7 @@ func NewBuildpacks(p *config.KfParams, l buildpacks.Client) *cobra.Command {
 				return err
 			}
 
-			w := tabwriter.NewWriter(p.Output, 8, 4, 1, ' ', tabwriter.StripEscape)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 8, 4, 1, ' ', tabwriter.StripEscape)
 			fmt.Fprintln(w, "NAME\tPOSITION\tENABLED")
 			for i, bp := range bps {
 				fmt.Fprintf(w, "%s\t%d\t%v\n", bp, i, true)

--- a/pkg/kf/commands/buildpacks/buildpacks_test.go
+++ b/pkg/kf/commands/buildpacks/buildpacks_test.go
@@ -66,7 +66,6 @@ func TestBuildpacks(t *testing.T) {
 			cmd := cbuildpacks.NewBuildpacks(
 				&config.KfParams{
 					Namespace: tc.Namespace,
-					Output:    &buffer,
 				},
 				fake,
 			)

--- a/pkg/kf/commands/buildpacks/upload_buildpacks_test.go
+++ b/pkg/kf/commands/buildpacks/upload_buildpacks_test.go
@@ -89,10 +89,11 @@ func TestUploadBuildpacks(t *testing.T) {
 			c := cbuildpacks.NewUploadBuildpacks(
 				&config.KfParams{
 					Namespace: tc.Namespace,
-					Output:    &bytes.Buffer{},
 				},
 				fakeClient,
 			)
+			buffer := &bytes.Buffer{}
+			c.SetOutput(buffer)
 
 			if tc.Setup != nil {
 				tc.Setup(t, c, fakeClient)

--- a/pkg/kf/commands/config/config.go
+++ b/pkg/kf/commands/config/config.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"io"
 	"log"
 	"path/filepath"
 
@@ -37,7 +36,6 @@ import (
 
 // KfParams stores everything needed to interact with the user and Knative.
 type KfParams struct {
-	Output      io.Writer
 	Namespace   string
 	KubeCfgFile string
 	Verbose     bool

--- a/pkg/kf/commands/doctor/doctor.go
+++ b/pkg/kf/commands/doctor/doctor.go
@@ -91,6 +91,5 @@ Possible components are: ` + strings.Join(knownTestNames, ", "),
 		},
 	}
 
-	doctorCmd.SetOutput(p.Output)
 	return doctorCmd
 }

--- a/pkg/kf/commands/doctor/doctor_test.go
+++ b/pkg/kf/commands/doctor/doctor_test.go
@@ -84,9 +84,9 @@ func TestNewDoctorCommand(t *testing.T) {
 
 			c := NewDoctorCommand(&config.KfParams{
 				Namespace: tc.namespace,
-				Output:    buffer,
 			}, tc.diagnostics)
 
+			c.SetOutput(buffer)
 			c.SetArgs(tc.args)
 			gotErr := c.Execute()
 			if tc.wantErr != nil || gotErr != nil {

--- a/pkg/kf/commands/root.go
+++ b/pkg/kf/commands/root.go
@@ -31,9 +31,7 @@ import (
 
 // NewKfCommand creates the root kf command.
 func NewKfCommand() *cobra.Command {
-	p := &config.KfParams{
-		Output: os.Stdout,
-	}
+	p := &config.KfParams{}
 
 	var rootCmd = &cobra.Command{
 		Use:   "kf",

--- a/pkg/kf/commands/service-bindings/bind-service.go
+++ b/pkg/kf/commands/service-bindings/bind-service.go
@@ -61,7 +61,7 @@ func NewBindServiceCommand(p *config.KfParams, client servicebindings.ClientInte
 				return err
 			}
 
-			output.WriteBindingDetails(p.Output, binding)
+			output.WriteBindingDetails(cmd.OutOrStdout(), binding)
 			return nil
 		},
 	}
@@ -80,6 +80,5 @@ func NewBindServiceCommand(p *config.KfParams, client servicebindings.ClientInte
 		"",
 		"name to expose service instance to app process with (default: service instance name)")
 
-	createCmd.SetOutput(p.Output)
 	return createCmd
 }

--- a/pkg/kf/commands/service-bindings/bindings.go
+++ b/pkg/kf/commands/service-bindings/bindings.go
@@ -45,7 +45,7 @@ func NewListBindingsCommand(p *config.KfParams, client servicebindings.ClientInt
 				return err
 			}
 
-			w := tabwriter.NewWriter(p.Output, 8, 4, 1, ' ', tabwriter.StripEscape)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 8, 4, 1, ' ', tabwriter.StripEscape)
 			fmt.Fprintln(w, "NAME\tAPP\tBINDING NAME\tSERVICE\tSECRET\tREADY\tREASON")
 			for _, b := range bindings {
 				status := ""
@@ -83,6 +83,5 @@ func NewListBindingsCommand(p *config.KfParams, client servicebindings.ClientInt
 		"",
 		"service instance to display bindings for")
 
-	listCmd.SetOutput(p.Output)
 	return listCmd
 }

--- a/pkg/kf/commands/service-bindings/cli_test.go
+++ b/pkg/kf/commands/service-bindings/cli_test.go
@@ -57,7 +57,6 @@ func runTest(t *testing.T, tc serviceTest, newCommand commandFactory) {
 
 	buf := new(bytes.Buffer)
 	p := &config.KfParams{
-		Output:    buf,
 		Namespace: tc.Namespace,
 	}
 

--- a/pkg/kf/commands/service-bindings/vcap_services.go
+++ b/pkg/kf/commands/service-bindings/vcap_services.go
@@ -45,7 +45,7 @@ func NewVcapServicesCommand(p *config.KfParams, client servicebindings.ClientInt
 				return err
 			}
 
-			fmt.Fprintln(p.Output, string(out))
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
 
 			return nil
 		},

--- a/pkg/kf/commands/services/create-service.go
+++ b/pkg/kf/commands/services/create-service.go
@@ -56,7 +56,7 @@ func NewCreateServiceCommand(p *config.KfParams, client services.ClientInterface
 				return err
 			}
 
-			output.WriteInstanceDetails(p.Output, instance)
+			output.WriteInstanceDetails(cmd.OutOrStdout(), instance)
 			return nil
 		},
 	}
@@ -68,6 +68,5 @@ func NewCreateServiceCommand(p *config.KfParams, client services.ClientInterface
 		"{}",
 		"Valid JSON object containing service-specific configuration parameters, provided in-line or in a file.")
 
-	createCmd.SetOutput(p.Output)
 	return createCmd
 }

--- a/pkg/kf/commands/services/helpers_test.go
+++ b/pkg/kf/commands/services/helpers_test.go
@@ -57,7 +57,6 @@ func runTest(t *testing.T, tc serviceTest, newCommand commandFactory) {
 
 	buf := new(bytes.Buffer)
 	p := &config.KfParams{
-		Output:    buf,
 		Namespace: tc.Namespace,
 	}
 

--- a/pkg/kf/commands/services/marketplace.go
+++ b/pkg/kf/commands/services/marketplace.go
@@ -44,7 +44,7 @@ func NewMarketplaceCommand(p *config.KfParams, client services.ClientInterface) 
 
 			// We use a custom tabwriter rather than svcat outputs because the
 			// headings on there don't make sense for our target audience.
-			w := tabwriter.NewWriter(p.Output, 8, 4, 2, ' ', 0)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 8, 4, 2, ' ', 0)
 
 			if serviceName == "" {
 				fmt.Fprintf(w, "%d services can be used in namespace %q, use the --service flag to list the plans for a service\n", len(marketplace.Services), p.Namespace)

--- a/pkg/kf/commands/services/service.go
+++ b/pkg/kf/commands/services/service.go
@@ -41,9 +41,9 @@ func NewGetServiceCommand(p *config.KfParams, client services.ClientInterface) *
 			}
 
 			if instance == nil {
-				fmt.Fprintf(p.Output, "service %s not found", instanceName)
+				fmt.Fprintf(cmd.OutOrStdout(), "service %s not found", instanceName)
 			} else {
-				output.WriteInstance(p.Output, "table", *instance)
+				output.WriteInstance(cmd.OutOrStdout(), "table", *instance)
 			}
 
 			return nil

--- a/pkg/kf/commands/services/services.go
+++ b/pkg/kf/commands/services/services.go
@@ -38,7 +38,7 @@ func NewListServicesCommand(p *config.KfParams, client services.ClientInterface)
 				return err
 			}
 
-			output.WriteInstanceList(p.Output, "table", instances)
+			output.WriteInstanceList(cmd.OutOrStdout(), "table", instances)
 
 			return nil
 		},

--- a/pkg/kf/commands/spaces/create_test.go
+++ b/pkg/kf/commands/spaces/create_test.go
@@ -72,7 +72,7 @@ func TestNewCreateSpaceCommand(t *testing.T) {
 
 			buffer := &bytes.Buffer{}
 
-			c := NewCreateSpaceCommand(&config.KfParams{Namespace: "default", Output: buffer}, fakeSpaces)
+			c := NewCreateSpaceCommand(&config.KfParams{Namespace: "default"}, fakeSpaces)
 			c.SetOutput(buffer)
 			c.SetArgs(tc.args)
 

--- a/pkg/kf/commands/spaces/delete_test.go
+++ b/pkg/kf/commands/spaces/delete_test.go
@@ -68,7 +68,7 @@ func TestNewDeleteSpaceCommand(t *testing.T) {
 
 			buffer := &bytes.Buffer{}
 
-			c := NewDeleteSpaceCommand(&config.KfParams{Namespace: "default", Output: buffer}, fakeSpaces)
+			c := NewDeleteSpaceCommand(&config.KfParams{Namespace: "default"}, fakeSpaces)
 			c.SetOutput(buffer)
 			c.SetArgs(tc.args)
 

--- a/pkg/kf/commands/spaces/list.go
+++ b/pkg/kf/commands/spaces/list.go
@@ -39,7 +39,7 @@ func NewListSpacesCommand(p *config.KfParams, client spaces.Client) *cobra.Comma
 				return err
 			}
 
-			w := tabwriter.NewWriter(p.Output, 8, 4, 1, ' ', tabwriter.StripEscape)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 8, 4, 1, ' ', tabwriter.StripEscape)
 			defer w.Flush()
 
 			// Status is important here as spaces may be in a deleting status.

--- a/pkg/kf/commands/spaces/list_test.go
+++ b/pkg/kf/commands/spaces/list_test.go
@@ -86,7 +86,7 @@ func TestNewListSpacesCommand(t *testing.T) {
 
 			buffer := &bytes.Buffer{}
 
-			c := NewListSpacesCommand(&config.KfParams{Namespace: "default", Output: buffer}, fakeSpaces)
+			c := NewListSpacesCommand(&config.KfParams{Namespace: "default"}, fakeSpaces)
 			c.SetOutput(buffer)
 			c.SetArgs(tc.args)
 


### PR DESCRIPTION
Replaces all usage with `Command.OutOrStdout()`. `KfParams.Output` was
redundant.

fixes #60