### PR TITLE
Push now builds before creating a Knative service.

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,0 +1,12 @@
+# Differences between `kf` and `cf`
+
+This document notes deviations in behavior between `kf` and `cf` for
+user-facing tasks. For example, using Istio rather than the gorouter for traffic
+wouldn't be mentioned, but any visible side-effects that causes would be.
+
+The differences are broken down by command/workflow.
+
+## Push
+
+* If the CLI disconnects during a build in `kf` the app may not be updated
+  whereas in `cf` it might.

--- a/pkg/kf/builds/fake/fake_client.go
+++ b/pkg/kf/builds/fake/fake_client.go
@@ -120,3 +120,22 @@ func (mr *FakeClientMockRecorder) Status(arg0 interface{}, arg1 ...interface{}) 
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*FakeClient)(nil).Status), varargs...)
 }
+
+// Tail mocks base method
+func (m *FakeClient) Tail(arg0 string, arg1 ...builds.TailOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Tail", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Tail indicates an expected call of Tail
+func (mr *FakeClientMockRecorder) Tail(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tail", reflect.TypeOf((*FakeClient)(nil).Tail), varargs...)
+}

--- a/pkg/kf/builds/options.yml
+++ b/pkg/kf/builds/options.yml
@@ -1,7 +1,7 @@
 # This file contains options for option-builder.go
 ---
 package: builds
-imports: {"k8s.io/apimachinery/pkg/apis/meta/v1":""}
+imports: {"k8s.io/apimachinery/pkg/apis/meta/v1":"", "io":"", "context":"", "os":""}
 common:
 - name: Namespace
   type: string
@@ -24,3 +24,11 @@ configs:
     description: a reference to the owner of this build
 - name: Status
 - name: Delete
+- name: Tail
+  options:
+  - name: Writer
+    type: "io.Writer"
+    default: "os.Stdout"
+  - name: Context
+    type: context.Context
+    default: "context.Background()"

--- a/pkg/kf/builds/util.go
+++ b/pkg/kf/builds/util.go
@@ -15,7 +15,9 @@
 package builds
 
 import (
+	"context"
 	"fmt"
+	"io"
 
 	build "github.com/knative/build/pkg/apis/build/v1alpha1"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
@@ -97,4 +99,12 @@ func PopulateTemplate(
 	}
 
 	return out
+}
+
+// BuildTailerFunc converts a func into a BuildTailer.
+type BuildTailerFunc func(ctx context.Context, out io.Writer, buildName, namespace string) error
+
+// Tail implements BuildTailer.
+func (f BuildTailerFunc) Tail(ctx context.Context, out io.Writer, buildName, namespace string) error {
+	return f(ctx, out, buildName, namespace)
 }

--- a/pkg/kf/commands/apps/push.go
+++ b/pkg/kf/commands/apps/push.go
@@ -17,9 +17,7 @@ package apps
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"path/filepath"
-	"time"
 
 	"github.com/GoogleCloudPlatform/kf/pkg/kf"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/commands/config"
@@ -121,7 +119,7 @@ func NewPushCommand(p *config.KfParams, pusher kf.Pusher, b SrcImageBuilder) *co
 				case sourceImage != "":
 					imageName = sourceImage
 				default:
-					imageName = fmt.Sprintf("%s/src-%s-%d%d", containerRegistry, app.Name, time.Now().UnixNano(), rand.Uint64())
+					imageName = kf.JoinRepositoryImage(containerRegistry, kf.SourceImageName(p.Namespace, app.Name))
 
 					if err := b.BuildSrcImage(srcPath, imageName); err != nil {
 						return err

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -60,7 +60,7 @@ func TestPushCommand(t *testing.T) {
 			buildpack:         "some-buildpack",
 			envVars:           []string{"env1=val1", "env2=val2"},
 			wantEnvMap:        map[string]string{"env1": "val1", "env2": "val2"},
-			wantImagePrefix:   "some-reg.io/src-app-name",
+			wantImagePrefix:   "some-reg.io/src-some-namespace-app-name",
 			srcImageBuilder: func(dir, srcImage string) error {
 				testutil.AssertEqual(t, "path", true, strings.Contains(dir, "some-path"))
 				testutil.AssertEqual(t, "path is abs", true, filepath.IsAbs(dir))
@@ -91,12 +91,13 @@ func TestPushCommand(t *testing.T) {
 			wantImagePrefix:   "custom-reg.io/source-image:latest",
 		},
 		"service create error": {
+			namespace:         "default",
 			args:              []string{"app-name"},
 			wantErr:           errors.New("some error"),
 			pusherErr:         errors.New("some error"),
 			containerRegistry: "some-reg.io",
 			serviceAccount:    "some-service-account",
-			wantImagePrefix:   "some-reg.io/src-app-name",
+			wantImagePrefix:   "some-reg.io/src-default-app-name",
 		},
 		"container-registry is not provided": {
 			namespace:         "some-namespace",

--- a/pkg/kf/commands/utils/command_override_fetcher.go
+++ b/pkg/kf/commands/utils/command_override_fetcher.go
@@ -30,7 +30,7 @@ import (
 
 	kf "github.com/GoogleCloudPlatform/kf/pkg/apis/kf/v1alpha1"
 	ckf "github.com/GoogleCloudPlatform/kf/pkg/client/clientset/versioned/typed/kf/v1alpha1"
-	pkf "github.com/GoogleCloudPlatform/kf/pkg/kf"
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/builds"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/commands/apps"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/commands/config"
 	build "github.com/knative/build/pkg/apis/build/v1alpha1"
@@ -48,7 +48,7 @@ type CommandOverrideFetcher interface {
 type commandOverrideFetcher struct {
 	kfClient     ckf.KfV1alpha1Interface
 	buildClient  cbuild.BuildV1alpha1Interface
-	tailer       pkf.BuildTailer
+	tailer       builds.BuildTailer
 	imageBuilder apps.SrcImageBuilder
 	params       *config.KfParams
 }
@@ -56,7 +56,7 @@ type commandOverrideFetcher struct {
 func NewCommandOverrideFetcher(
 	kfClient ckf.KfV1alpha1Interface,
 	buildClient cbuild.BuildV1alpha1Interface,
-	tailer pkf.BuildTailer,
+	tailer builds.BuildTailer,
 	imageBuilder apps.SrcImageBuilder,
 	params *config.KfParams,
 ) CommandOverrideFetcher {
@@ -104,7 +104,7 @@ func (f *commandOverrideFetcher) buildCommand(
 	set kf.CommandSet,
 	spec kf.CommandSpec,
 	imageBuilder apps.SrcImageBuilder,
-	tailer pkf.BuildTailer,
+	tailer builds.BuildTailer,
 ) (*cobra.Command, error) {
 	var (
 		dir            string

--- a/pkg/kf/commands/utils/command_override_fetcher_test.go
+++ b/pkg/kf/commands/utils/command_override_fetcher_test.go
@@ -23,8 +23,8 @@ import (
 
 	kf "github.com/GoogleCloudPlatform/kf/pkg/apis/kf/v1alpha1"
 	"github.com/GoogleCloudPlatform/kf/pkg/client/clientset/versioned/typed/kf/v1alpha1/fake"
-	pkf "github.com/GoogleCloudPlatform/kf/pkg/kf"
 
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/builds"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/commands/apps"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/commands/config"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/commands/utils"
@@ -42,7 +42,7 @@ func TestCommandOverrideFetcher(t *testing.T) {
 
 	for tn, tc := range map[string]struct {
 		Namespace          string
-		BuildTailer        func(*testing.T) pkf.BuildTailer
+		BuildTailer        func(*testing.T) builds.BuildTailer
 		BuildImage         func(*testing.T) apps.SrcImageBuilder
 		ListReactor        ktesting.ReactionFunc
 		CreateBuildReactor ktesting.ReactionFunc
@@ -241,8 +241,8 @@ func TestCommandOverrideFetcher(t *testing.T) {
 
 				return true, b, nil
 			}),
-			BuildTailer: func(t *testing.T) pkf.BuildTailer {
-				return pkf.BuildTailerFunc(func(ctx context.Context, w io.Writer, name, namespace string) error {
+			BuildTailer: func(t *testing.T) builds.BuildTailer {
+				return builds.BuildTailerFunc(func(ctx context.Context, w io.Writer, name, namespace string) error {
 					if ctx == nil {
 						t.Fatal("expected ctx to not be nil")
 					}
@@ -378,8 +378,8 @@ func TestCommandOverrideFetcher(t *testing.T) {
 			}
 
 			if tc.BuildTailer == nil {
-				tc.BuildTailer = func(*testing.T) pkf.BuildTailer {
-					return pkf.BuildTailerFunc(func(ctx context.Context, w io.Writer, name, namespace string) error {
+				tc.BuildTailer = func(*testing.T) builds.BuildTailer {
+					return builds.BuildTailerFunc(func(ctx context.Context, w io.Writer, name, namespace string) error {
 						return nil
 					})
 				}

--- a/pkg/kf/commands/wire_injector.go
+++ b/pkg/kf/commands/wire_injector.go
@@ -22,6 +22,7 @@ import (
 	"github.com/GoogleCloudPlatform/kf/pkg/kf"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/apps"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/buildpacks"
+	"github.com/GoogleCloudPlatform/kf/pkg/kf/builds"
 	capps "github.com/GoogleCloudPlatform/kf/pkg/kf/commands/apps"
 	cbuildpacks "github.com/GoogleCloudPlatform/kf/pkg/kf/commands/buildpacks"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/commands/config"
@@ -53,8 +54,8 @@ func provideSrcImageBuilder() capps.SrcImageBuilder {
 	return capps.SrcImageBuilderFunc(kontext.BuildImage)
 }
 
-func provideBuildTailer() kf.BuildTailer {
-	return kf.BuildTailerFunc(logs.Tail)
+func provideBuildTailer() builds.BuildTailer {
+	return builds.BuildTailerFunc(logs.Tail)
 }
 
 ///////////////////
@@ -74,6 +75,7 @@ func InjectPush(p *config.KfParams) *cobra.Command {
 		kf.NewLogTailer,
 		kf.NewDeployer,
 		config.GetBuildClient,
+		builds.NewClient,
 		provideSrcImageBuilder,
 		provideBuildTailer,
 		AppsSet,

--- a/pkg/kf/log_tailer.go
+++ b/pkg/kf/log_tailer.go
@@ -15,17 +15,12 @@
 package kf
 
 import (
-	"context"
 	"fmt"
 	"io"
 
-	"github.com/GoogleCloudPlatform/kf/pkg/kf/builds"
-	build "github.com/knative/build/pkg/apis/build/v1alpha1"
-	cbuild "github.com/knative/build/pkg/client/clientset/versioned/typed/build/v1alpha1"
 	serving "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	cserving "github.com/knative/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
 )
 
 // Logs handles build and deploy logs.
@@ -35,105 +30,22 @@ type Logs interface {
 	DeployLogs(out io.Writer, appName, resourceVersion, namespace string) error
 }
 
-// BuildTailer writes the build logs to out.
-type BuildTailer interface {
-	Tail(ctx context.Context, out io.Writer, buildName, namespace string) error
-}
-
-// BuildTailerFunc converts a func into a BuildTailer.
-type BuildTailerFunc func(ctx context.Context, out io.Writer, buildName, namespace string) error
-
-// Tail implements BuildTailer.
-func (f BuildTailerFunc) Tail(ctx context.Context, out io.Writer, buildName, namespace string) error {
-	return f(ctx, out, buildName, namespace)
-}
-
 // logTailer tails logs for a service. This includes the build and deploy
 // step. It should be created via NewLogTailer.
 type logTailer struct {
-	bc cbuild.BuildV1alpha1Interface
 	sc cserving.ServingV1alpha1Interface
-	t  BuildTailer
 }
 
 // NewLogTailer creates a new Logs.
-func NewLogTailer(
-	bc cbuild.BuildV1alpha1Interface,
-	sc cserving.ServingV1alpha1Interface,
-	t BuildTailer,
-) Logs {
+func NewLogTailer(sc cserving.ServingV1alpha1Interface) Logs {
 	return &logTailer{
-		bc: bc,
 		sc: sc,
-		t:  t,
 	}
 }
 
-// DeployLogs writes the logs for the build and deploy step for the resourceVersion
+// DeployLogs writes the logs for the deploy step for the resourceVersion
 // to out. It blocks until the operation has completed.
 func (t logTailer) DeployLogs(out io.Writer, appName, resourceVersion, namespace string) error {
-	errs := make(chan error, 2)
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	go func() { errs <- t.buildLogs(ctx, out, appName, resourceVersion, namespace) }()
-	go func() { errs <- t.serviceLogs(cancel, out, appName, resourceVersion, namespace) }()
-
-	err1, err2 := <-errs, <-errs
-	for _, err := range []error{err1, err2} {
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (t logTailer) buildLogs(ctx context.Context, out io.Writer, appName, resourceVersion, namespace string) error {
-	wb, err := t.bc.Builds(namespace).Watch(k8smeta.ListOptions{
-		ResourceVersion: resourceVersion,
-		Watch:           true,
-	})
-	if err != nil {
-		return err
-	}
-	defer wb.Stop()
-
-	go func() {
-		<-ctx.Done()
-		wb.Stop()
-	}()
-
-	for e := range wb.ResultChan() {
-		obj := e.Object.(*build.Build)
-		var foundRef bool
-		for _, ref := range obj.ObjectMeta.OwnerReferences {
-			if ref.Name == appName {
-				foundRef = true
-				break
-			}
-		}
-		if !foundRef {
-			continue
-		}
-
-		if e.Type == watch.Added {
-			// This blocks until the build is finished.
-			if err := t.t.Tail(ctx, out, obj.Name, namespace); err != nil {
-				return err
-			}
-		}
-
-		if finished, err := builds.BuildStatus(*obj); finished {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (t logTailer) serviceLogs(done func(), out io.Writer, appName, resourceVersion, namespace string) error {
-	defer done()
 	ws, err := t.sc.Services(namespace).Watch(k8smeta.ListOptions{
 		ResourceVersion: resourceVersion,
 		Watch:           true,


### PR DESCRIPTION
This PR is part of #111. It moves build tailing into the builds client and makes push use that before creating a Knative service.