### PR TITLE
pkg/kf/commands/apps: fix flaky/broken integration tests

### DIFF
--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -33,9 +33,9 @@ import (
 	. "github.com/GoogleCloudPlatform/kf/pkg/kf/testutil"
 )
 
-// TestIntegration_Push pushes the echo app (via --built-in command), lists it
-// to ensure it can find a domain, uses the proxy command and then posts to
-// it. It finally deletes the app.
+// TestIntegration_Push pushes the echo app, lists it to ensure it can find a
+// domain, uses the proxy command and then posts to it. It finally deletes the
+// app.
 func TestIntegration_Push(t *testing.T) {
 	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
@@ -44,7 +44,6 @@ func TestIntegration_Push(t *testing.T) {
 		// Push an app and then clean it up. This pushes the echo app which
 		// replies with the same body that was posted.
 		kf.Push(ctx, appName,
-			"--built-in",
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
 			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
 		)
@@ -96,7 +95,6 @@ func TestIntegration_Push_manifest(t *testing.T) {
 
 		// Push an app with a manifest file.
 		kf.Push(ctx, appName,
-			"--built-in",
 			"--path", appPath,
 			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
 			"--manifest", newManifestFile,
@@ -171,7 +169,6 @@ func TestIntegration_Delete(t *testing.T) {
 		// Push an app and then clean it up. This pushes the echo app which
 		// simplies replies with the same body that was posted.
 		kf.Push(ctx, appName,
-			"--built-in",
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
 			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
 		)
@@ -209,7 +206,6 @@ func TestIntegration_Envs(t *testing.T) {
 		// returns the set environment variables via JSON. Set two environment
 		// variables (ENV1 and ENV2).
 		kf.Push(ctx, appName,
-			"--built-in",
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/envs"),
 			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
 			"--env", "ENV1=VALUE1",
@@ -230,10 +226,10 @@ func TestIntegration_Envs(t *testing.T) {
 		}, nil)
 
 		// Unset the environment variables ENV1.
-		kf.UnsetEnv(ctx, appName, "ENV1")
+		RetryOnPanic(ctx, t, func() { kf.UnsetEnv(ctx, appName, "ENV1") })
 
 		// Overwrite ENV2 via set-env
-		kf.SetEnv(ctx, appName, "ENV2", "OVERWRITE2")
+		RetryOnPanic(ctx, t, func() { kf.SetEnv(ctx, appName, "ENV2", "OVERWRITE2") })
 
 		checkVars(ctx, t, kf, appName, 8081, map[string]string{
 			"ENV2": "OVERWRITE2", // Set on push and overwritten via set-env
@@ -241,7 +237,7 @@ func TestIntegration_Envs(t *testing.T) {
 	})
 }
 
-// TestIntegration_Logs pushes the echo app (via --built-in command), tails
+// TestIntegration_Logs pushes the echo app, tails
 // it's logs and then posts to it. It then waits for the expected logs. It
 // finally deletes the app.
 func TestIntegration_Logs(t *testing.T) {
@@ -252,7 +248,6 @@ func TestIntegration_Logs(t *testing.T) {
 		// Push an app and then clean it up. This pushes the echo app which
 		// replies with the same body that was posted.
 		kf.Push(ctx, appName,
-			"--built-in",
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
 			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
 		)

--- a/pkg/kf/testutil/integration.go
+++ b/pkg/kf/testutil/integration.go
@@ -237,6 +237,26 @@ func RootDir(ctx context.Context, t *testing.T) string {
 	return strings.TrimSpace(string(data))
 }
 
+// RetryOnPanic will retry the function if it panics (e.g., via PanicOnError)
+// until the given context is cancelled or the given function succeeds without
+// panicking.
+func RetryOnPanic(ctx context.Context, t *testing.T, f func()) {
+	var success bool
+	for !success && ctx.Err() == nil {
+		func() {
+			defer func() {
+				if err := recover(); err == nil {
+					Logf(t, "got err: %s. Retrying...", err)
+					return
+				}
+				success = true
+			}()
+
+			f()
+		}()
+	}
+}
+
 // PanicOnError launches a go routine and waits for either the context or an
 // error. An error will result in a panic. Why a panic in a test? t.Fatal is
 // not thread safe. T.Failed() is thread safe, therefore we can use that to
@@ -435,7 +455,7 @@ func (k *Kf) Apps(ctx context.Context) map[string]AppInfo {
 	defer Logf(k.t, "done listing apps.")
 	k.t.Helper()
 	output, errs := k.kf(ctx, k.t, KfTestConfig{
-		Args: []string{"apps", "--built-in"},
+		Args: []string{"apps"},
 	})
 	PanicOnError(ctx, k.t, "apps", errs)
 	apps := CombineOutputStr(ctx, k.t, output)
@@ -479,7 +499,6 @@ func (k *Kf) Delete(ctx context.Context, appName string) {
 	output, errs := k.kf(ctx, k.t, KfTestConfig{
 		Args: []string{
 			"delete",
-			"--built-in",
 			appName,
 		},
 	})
@@ -495,7 +514,6 @@ func (k *Kf) Proxy(ctx context.Context, appName string, port int) {
 	output, errs := k.kf(ctx, k.t, KfTestConfig{
 		Args: []string{
 			"proxy",
-			"--built-in",
 			appName,
 			fmt.Sprintf("--port=%d", port),
 		},
@@ -512,7 +530,6 @@ func (k *Kf) SetEnv(ctx context.Context, appName, name, value string) {
 	output, errs := k.kf(ctx, k.t, KfTestConfig{
 		Args: []string{
 			"set-env",
-			"--built-in",
 			appName,
 			name,
 			value,
@@ -530,7 +547,6 @@ func (k *Kf) UnsetEnv(ctx context.Context, appName, name string) {
 	output, errs := k.kf(ctx, k.t, KfTestConfig{
 		Args: []string{
 			"unset-env",
-			"--built-in",
 			appName,
 			name,
 		},
@@ -547,7 +563,6 @@ func (k *Kf) Env(ctx context.Context, appName string) map[string]string {
 	output, errs := k.kf(ctx, k.t, KfTestConfig{
 		Args: []string{
 			"env",
-			"--built-in",
 			appName,
 		},
 	})
@@ -578,7 +593,6 @@ func (k *Kf) Doctor(ctx context.Context) {
 	output, errs := k.kf(ctx, k.t, KfTestConfig{
 		Args: []string{
 			"doctor",
-			"--built-in",
 		},
 	})
 	PanicOnError(ctx, k.t, "doctor", errs)
@@ -593,7 +607,6 @@ func (k *Kf) Buildpacks(ctx context.Context) []string {
 	output, errs := k.kf(ctx, k.t, KfTestConfig{
 		Args: []string{
 			"buildpacks",
-			"--built-in",
 		},
 	})
 	PanicOnError(ctx, k.t, "buildpacks", errs)


### PR DESCRIPTION
The integration tests were still using the --built-in flag and therefore
were panicking. They also had a timing issue with the Env tests that now
use retries.

fixes #161