### PR TITLE
moved push to use getters/setters on kfapp

### DIFF
--- a/pkg/kf/apps/kfapp.go
+++ b/pkg/kf/apps/kfapp.go
@@ -18,6 +18,7 @@ import (
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/internal/envutil"
 	serving "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // KfApp provides a facade around Knative services for accessing and mutating its
@@ -34,22 +35,99 @@ func (k *KfApp) SetName(name string) {
 	k.Name = name
 }
 
-// GetEnvVars reads the environment variables off an app.
-func (k *KfApp) GetEnvVars() []corev1.EnvVar {
-	if k == nil || k.Spec.RunLatest == nil {
-		return nil
-	}
-
-	return k.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Env
+// SetNamespace sets the namespace for the app.
+func (k *KfApp) SetNamespace(namespace string) {
+	k.Namespace = namespace
 }
 
-// SetEnvVars sets environment variables on an app.
-func (k *KfApp) SetEnvVars(env []corev1.EnvVar) {
+// GetNamespace gets the namespace for the app.
+func (k *KfApp) GetNamespace() string {
+	return k.Namespace
+}
+
+func (k *KfApp) getOrCreateRunLatest() *serving.RunLatestType {
 	if k.Spec.RunLatest == nil {
 		k.Spec.RunLatest = &serving.RunLatestType{}
 	}
 
-	k.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Env = env
+	return k.Spec.RunLatest
+}
+
+func (k *KfApp) getRunLatestOrNil() *serving.RunLatestType {
+	if k == nil {
+		return nil
+	}
+	return k.Spec.RunLatest
+}
+
+func (k *KfApp) getOrCreateContainer() *corev1.Container {
+	return &k.getOrCreateRunLatest().Configuration.RevisionTemplate.Spec.Container
+}
+
+func (k *KfApp) getContainerOrNil() *corev1.Container {
+	if rl := k.getRunLatestOrNil(); rl != nil {
+		return &rl.Configuration.RevisionTemplate.Spec.Container
+	}
+
+	return nil
+}
+
+// SetImage sets the image for the application and a policy to always refresh it.
+func (k *KfApp) SetImage(imageName string) {
+	container := k.getOrCreateContainer()
+	container.ImagePullPolicy = "Always"
+	container.Image = imageName
+}
+
+// GetImage gets the image associated with the container.
+func (k *KfApp) GetImage() string {
+	if container := k.getContainerOrNil(); container != nil {
+		return container.Image
+	}
+
+	return ""
+}
+
+// SetContainerPorts sets the ports the container will open.
+func (k *KfApp) SetContainerPorts(ports []corev1.ContainerPort) {
+	k.getOrCreateContainer().Ports = ports
+}
+
+// GetContainerPorts gets the ports the container will open.
+func (k *KfApp) GetContainerPorts() []corev1.ContainerPort {
+	if container := k.getContainerOrNil(); container != nil {
+		return container.Ports
+	}
+
+	return nil
+}
+
+// SetServiceAccount sets the account the application will run as.
+func (k *KfApp) SetServiceAccount(sa string) {
+	k.getOrCreateRunLatest().Configuration.RevisionTemplate.Spec.ServiceAccountName = sa
+}
+
+// GetServiceAccount returns the service account used by the container.
+func (k *KfApp) GetServiceAccount() string {
+	if rl := k.getRunLatestOrNil(); rl != nil {
+		return rl.Configuration.RevisionTemplate.Spec.ServiceAccountName
+	}
+
+	return ""
+}
+
+// GetEnvVars reads the environment variables off an app.
+func (k *KfApp) GetEnvVars() []corev1.EnvVar {
+	if container := k.getContainerOrNil(); container != nil {
+		return container.Env
+	}
+
+	return nil
+}
+
+// SetEnvVars sets environment variables on an app.
+func (k *KfApp) SetEnvVars(env []corev1.EnvVar) {
+	k.getOrCreateContainer().Env = env
 }
 
 // MergeEnvVars adds the environment variables listed to the existing ones,
@@ -71,5 +149,10 @@ func (k *KfApp) ToService() *serving.Service {
 
 // NewKfApp creates a new KfApp.
 func NewKfApp() KfApp {
-	return KfApp{}
+	return KfApp{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "serving.knative.dev/v1alpha1",
+		},
+	}
 }

--- a/pkg/kf/apps/kfapp_test.go
+++ b/pkg/kf/apps/kfapp_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/testutil"
 	serving "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func ExampleKfApp() {
@@ -39,7 +40,12 @@ func TestKfApp_ToService(t *testing.T) {
 	app.SetName("foo")
 	actual := app.ToService()
 
-	expected := &serving.Service{}
+	expected := &serving.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "serving.knative.dev/v1alpha1",
+		},
+	}
 	expected.Name = "foo"
 
 	testutil.AssertEqual(t, "generated service", expected, actual)
@@ -109,4 +115,50 @@ func ExampleKfApp_DeleteEnvVars() {
 	}
 
 	// Output: Key BAR Value 0
+}
+
+func ExampleKfApp_GetNamespace() {
+	myApp := NewKfApp()
+	myApp.SetNamespace("my-ns")
+
+	fmt.Println(myApp.GetNamespace())
+
+	// Output: my-ns
+}
+
+func ExampleKfApp_GetServiceAccount() {
+	myApp := NewKfApp()
+	fmt.Printf("Default: %q\n", myApp.GetServiceAccount())
+
+	myApp.SetServiceAccount("my-sa")
+	fmt.Printf("After set: %q\n", myApp.GetServiceAccount())
+
+	// Output: Default: ""
+	// After set: "my-sa"
+}
+
+func ExampleKfApp_GetImage() {
+	myApp := NewKfApp()
+	fmt.Printf("Default: %q\n", myApp.GetImage())
+
+	myApp.SetImage("my-company/my-app")
+	fmt.Printf("After set: %q\n", myApp.GetImage())
+
+	// Output: Default: ""
+	// After set: "my-company/my-app"
+}
+
+func ExampleKfApp_GetContainerPorts() {
+	myApp := NewKfApp()
+	fmt.Printf("Default: %v\n", myApp.GetContainerPorts())
+
+	myApp.SetContainerPorts([]corev1.ContainerPort{{Name: "HTTP", ContainerPort: 8080}})
+
+	for _, port := range myApp.GetContainerPorts() {
+		fmt.Printf("Open %d (%s)\n", port.ContainerPort, port.Name)
+
+	}
+
+	// Output: Default: []
+	// Open 8080 (HTTP)
 }

--- a/pkg/kf/deploy_test.go
+++ b/pkg/kf/deploy_test.go
@@ -139,11 +139,8 @@ func TestDeploy(t *testing.T) {
 }
 
 func buildServiceWithEnvs(appName string, envs map[string]string) serving.Service {
-	s := serving.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: appName,
-		},
-	}
-	envutil.SetServiceEnvVars(&s, envutil.MapToEnvVars(envs))
-	return s
+	app := apps.NewKfApp()
+	app.SetName(appName)
+	app.SetEnvVars(envutil.MapToEnvVars(envs))
+	return *app.ToService()
 }


### PR DESCRIPTION
This moves most of our direct accesses of child application properties into getters and setters prepping us to move to Knative 0.6 and eventually a custom CRD #111 