### PR TITLE
hack: publish the stack when uploading buildpacks

### DIFF
--- a/hack/upload-buildpacks-stack.sh
+++ b/hack/upload-buildpacks-stack.sh
@@ -19,8 +19,6 @@ set -eu
 version=${VERSION:-latest}
 publish=${PUBLISH:-false}
 
-# docker pull "ubunutu:bionic"
-
 rootpath=$(cd $(dirname $0)/.. && pwd)
 dir=${rootpath}/samples/buildpacks/stacks/bionic
 gcr=gcr.io/$(gcloud config get-value project)

--- a/hack/upload-buildpacks.sh
+++ b/hack/upload-buildpacks.sh
@@ -19,7 +19,7 @@ set -eu
 scriptpath=$(cd $(dirname $0)/.. && pwd)
 
 # Upload stacks
-$scriptpath/hack/upload-buildpacks-stack.sh
+PUBLISH=true $scriptpath/hack/upload-buildpacks-stack.sh
 
 samples=$(realpath $scriptpath/samples)
 builder_config=$samples/buildpacks/builder/builder.toml


### PR DESCRIPTION
Previous this CL, the upload-buildpacks.sh script would use the
upload-buildpacks-stack.sh script without publishing the results. This
implied that if the latter script had never ran within that project,
then it would fail. Otherwise it would use an existing stack.

fixes #172