### PR TITLE
pkg/kf/commands/apps: skips env overwrite test

### DIFF
--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -225,15 +225,18 @@ func TestIntegration_Envs(t *testing.T) {
 			"ENV2": "VALUE2", // Set on push
 		}, nil)
 
-		// Unset the environment variables ENV1.
-		RetryOnPanic(ctx, t, func() { kf.UnsetEnv(ctx, appName, "ENV1") })
+		t.Run("overwrite envs", func(t *testing.T) {
+			t.Skip("this is flaky as knative isn't fast at updating the env values")
+			// Unset the environment variables ENV1.
+			RetryOnPanic(ctx, t, func() { kf.UnsetEnv(ctx, appName, "ENV1") })
 
-		// Overwrite ENV2 via set-env
-		RetryOnPanic(ctx, t, func() { kf.SetEnv(ctx, appName, "ENV2", "OVERWRITE2") })
+			// Overwrite ENV2 via set-env
+			RetryOnPanic(ctx, t, func() { kf.SetEnv(ctx, appName, "ENV2", "OVERWRITE2") })
 
-		checkVars(ctx, t, kf, appName, 8081, map[string]string{
-			"ENV2": "OVERWRITE2", // Set on push and overwritten via set-env
-		}, []string{"ENV1"})
+			checkVars(ctx, t, kf, appName, 8081, map[string]string{
+				"ENV2": "OVERWRITE2", // Set on push and overwritten via set-env
+			}, []string{"ENV1"})
+		})
 	})
 }
 


### PR DESCRIPTION
The integration test that tests an application's environment variable's
value being overwritten has a tendency to be flaky. This CL skips this
part of the test until it is more reliable.