### PR TITLE
Fix create quota command

### DIFF
--- a/pkg/kf/commands/quotas/create.go
+++ b/pkg/kf/commands/quotas/create.go
@@ -44,6 +44,7 @@ func NewCreateQuotaCommand(p *config.KfParams, client quotas.Client) *cobra.Comm
 			name := args[0]
 
 			kfquota := quotas.NewKfQuota()
+			kfquota.SetName(name)
 			err := setQuotaValues(memory, cpu, routes, &kfquota)
 			if err != nil {
 				return err


### PR DESCRIPTION
accidentally removed the line to set quota name, which causes creation to fail