### PR TITLE
Reset resource quota to unlimited

### DIFF
--- a/pkg/kf/commands/quotas/create.go
+++ b/pkg/kf/commands/quotas/create.go
@@ -44,6 +44,7 @@ func NewCreateQuotaCommand(p *config.KfParams, client quotas.Client) *cobra.Comm
 			name := args[0]
 
 			kfquota := quotas.NewKfQuota()
+			kfquota.SetName(name)
 			err := setQuotaValues(memory, cpu, routes, &kfquota)
 			if err != nil {
 				return err

--- a/pkg/kf/commands/quotas/get.go
+++ b/pkg/kf/commands/quotas/get.go
@@ -45,9 +45,9 @@ func NewGetQuotaCommand(p *config.KfParams, client quotas.Client) *cobra.Command
 
 			fmt.Fprintln(w, "NAME\tMEMORY\tCPU\tROUTES")
 			kfquota := quotas.NewFromResourceQuota(quota)
-			mem := kfquota.GetMemory()
-			cpu := kfquota.GetCPU()
-			routes := kfquota.GetServices()
+			mem, _ := kfquota.GetMemory()
+			cpu, _ := kfquota.GetCPU()
+			routes, _ := kfquota.GetServices()
 			fmt.Fprintf(w, "%s\t%v\t%v\t%v\n",
 				kfquota.GetName(),
 				mem.String(),

--- a/pkg/kf/commands/quotas/list.go
+++ b/pkg/kf/commands/quotas/list.go
@@ -47,9 +47,9 @@ func NewListQuotasCommand(p *config.KfParams, client quotas.Client) *cobra.Comma
 			fmt.Fprintln(w, "NAME\tMEMORY\tCPU\tROUTES")
 			for _, quota := range allQuotas {
 				kfquota := quotas.NewFromResourceQuota(&quota)
-				mem := kfquota.GetMemory()
-				cpu := kfquota.GetCPU()
-				routes := kfquota.GetServices()
+				mem, _ := kfquota.GetMemory()
+				cpu, _ := kfquota.GetCPU()
+				routes, _ := kfquota.GetServices()
 				fmt.Fprintf(w, "%s\t%v\t%v\t%v\n",
 					kfquota.GetName(),
 					mem.String(),

--- a/pkg/kf/commands/quotas/utils.go
+++ b/pkg/kf/commands/quotas/utils.go
@@ -28,9 +28,9 @@ func setQuotaValues(memory string, cpu string, routes string, kfquota *quotas.Kf
 		Setter   func(r resource.Quantity)
 		Resetter func()
 	}{
-		{memory, kfquota.SetMemory, kfquota.RemoveMemory},
-		{cpu, kfquota.SetCPU, kfquota.RemoveCPU},
-		{routes, kfquota.SetServices, kfquota.RemoveServices},
+		{memory, kfquota.SetMemory, kfquota.ResetMemory},
+		{cpu, kfquota.SetCPU, kfquota.ResetCPU},
+		{routes, kfquota.SetServices, kfquota.ResetServices},
 	}
 
 	// Only update resource quotas for inputted flags
@@ -40,10 +40,11 @@ func setQuotaValues(memory string, cpu string, routes string, kfquota *quotas.Kf
 			if err != nil {
 				return fmt.Errorf("couldn't parse resource quantity %s: %v", quota.Value, err)
 			}
-			if quota.Value != "0" {
-				quota.Setter(quantity)
-			} else {
+			// Passing in 0 for a resource resets its quota to unlimited
+			if quantity.IsZero() {
 				quota.Resetter()
+			} else {
+				quota.Setter(quantity)
 			}
 		}
 	}

--- a/pkg/kf/quotas/kfquota.go
+++ b/pkg/kf/quotas/kfquota.go
@@ -34,8 +34,9 @@ func (k *KfQuota) SetName(name string) {
 }
 
 // GetMemory returns the quota for total memory in a space.
-func (k *KfQuota) GetMemory() resource.Quantity {
-	return k.Spec.Hard[v1.ResourceMemory]
+func (k *KfQuota) GetMemory() (resource.Quantity, bool) {
+	quantity, quotaExists := k.Spec.Hard[v1.ResourceMemory]
+	return quantity, quotaExists
 }
 
 // SetMemory sets the quota for total memory in a space.
@@ -47,14 +48,15 @@ func (k *KfQuota) SetMemory(memoryLimit resource.Quantity) {
 	k.Spec.Hard[v1.ResourceMemory] = memoryLimit
 }
 
-// RemoveMemory resets the quota for total memory in a space to unlimited.
-func (k *KfQuota) RemoveMemory() {
+// ResetMemory resets the quota for total memory in a space to unlimited.
+func (k *KfQuota) ResetMemory() {
 	delete(k.Spec.Hard, v1.ResourceMemory)
 }
 
 // GetCPU returns the quota for total CPU in a space.
-func (k *KfQuota) GetCPU() resource.Quantity {
-	return k.Spec.Hard[v1.ResourceCPU]
+func (k *KfQuota) GetCPU() (resource.Quantity, bool) {
+	quantity, quotaExists := k.Spec.Hard[v1.ResourceCPU]
+	return quantity, quotaExists
 }
 
 // SetCPU sets the quota for total CPU in a space.
@@ -66,14 +68,15 @@ func (k *KfQuota) SetCPU(cpuLimit resource.Quantity) {
 	k.Spec.Hard[v1.ResourceCPU] = cpuLimit
 }
 
-// RemoveCPU resets the quota for total CPU in a space to unlimited.
-func (k *KfQuota) RemoveCPU() {
+// ResetCPU resets the quota for total CPU in a space to unlimited.
+func (k *KfQuota) ResetCPU() {
 	delete(k.Spec.Hard, v1.ResourceCPU)
 }
 
 // GetServices returns the quota for total number of routes in a space.
-func (k *KfQuota) GetServices() resource.Quantity {
-	return k.Spec.Hard[v1.ResourceServices]
+func (k *KfQuota) GetServices() (resource.Quantity, bool) {
+	quantity, quotaExists := k.Spec.Hard[v1.ResourceServices]
+	return quantity, quotaExists
 }
 
 // SetServices sets the quota for total number of routes in a space.
@@ -85,9 +88,9 @@ func (k *KfQuota) SetServices(numServices resource.Quantity) {
 	k.Spec.Hard[v1.ResourceServices] = numServices
 }
 
-// RemoveServices resets the quota for total number of routes in a space
+// ResetServices resets the quota for total number of routes in a space
 // to unlimited.
-func (k *KfQuota) RemoveServices() {
+func (k *KfQuota) ResetServices() {
 	delete(k.Spec.Hard, v1.ResourceServices)
 }
 

--- a/pkg/kf/quotas/kfquota.go
+++ b/pkg/kf/quotas/kfquota.go
@@ -47,18 +47,28 @@ func (k *KfQuota) SetMemory(memoryLimit resource.Quantity) {
 	k.Spec.Hard[v1.ResourceMemory] = memoryLimit
 }
 
+// RemoveMemory resets the quota for total memory in a space to unlimited.
+func (k *KfQuota) RemoveMemory() {
+	delete(k.Spec.Hard, v1.ResourceMemory)
+}
+
 // GetCPU returns the quota for total CPU in a space.
 func (k *KfQuota) GetCPU() resource.Quantity {
 	return k.Spec.Hard[v1.ResourceCPU]
 }
 
-// SetCPU sets the quota for total CPU in a sapce.
+// SetCPU sets the quota for total CPU in a space.
 func (k *KfQuota) SetCPU(cpuLimit resource.Quantity) {
 	if k.Spec.Hard == nil {
 		k.Spec.Hard = v1.ResourceList{}
 	}
 
 	k.Spec.Hard[v1.ResourceCPU] = cpuLimit
+}
+
+// RemoveCPU resets the quota for total CPU in a space to unlimited.
+func (k *KfQuota) RemoveCPU() {
+	delete(k.Spec.Hard, v1.ResourceCPU)
 }
 
 // GetServices returns the quota for total number of routes in a space.
@@ -73,6 +83,12 @@ func (k *KfQuota) SetServices(numServices resource.Quantity) {
 	}
 
 	k.Spec.Hard[v1.ResourceServices] = numServices
+}
+
+// RemoveServices resets the quota for total number of routes in a space
+// to unlimited.
+func (k *KfQuota) RemoveServices() {
+	delete(k.Spec.Hard, v1.ResourceServices)
 }
 
 // ToResourceQuota casts this alias back into a ResourceQuota.


### PR DESCRIPTION
reset a resource quota back to unlimited by passing in 0 for the desired resource in update command. (e.g. `kf update-quota test-quota -m 0` resets the memory quota to unlimited in `test-quota`)