### PR TITLE
pkg/kf/commands/routes: fix bug in deleting route

### DIFF
--- a/pkg/kf/commands/routes/delete_route.go
+++ b/pkg/kf/commands/routes/delete_route.go
@@ -16,6 +16,7 @@ package routes
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/commands/config"
 	"github.com/GoogleCloudPlatform/kf/pkg/kf/internal/routeutil"
@@ -41,6 +42,7 @@ func NewDeleteRouteCommand(
 		RunE: func(cmd *cobra.Command, args []string) error {
 			domain := args[0]
 			cmd.SilenceUsage = true
+			urlPath = path.Join("/", urlPath)
 
 			if err := c.Delete(p.Namespace, routeutil.EncodeRouteName(hostname, domain, urlPath)); err != nil {
 				return fmt.Errorf("failed to delete Route: %s", err)

--- a/pkg/kf/commands/routes/delete_route_test.go
+++ b/pkg/kf/commands/routes/delete_route_test.go
@@ -65,7 +65,7 @@ func TestDeleteRoute(t *testing.T) {
 			Args:      []string{"example.com", "--hostname=some-hostname", "--path=somepath"},
 			Namespace: "some-namespace",
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
-				expectedName := routeutil.EncodeRouteName("some-hostname", "example.com", "somepath")
+				expectedName := routeutil.EncodeRouteName("some-hostname", "example.com", "/somepath")
 				fake.EXPECT().Delete(
 					gomock.Any(),
 					expectedName,


### PR DESCRIPTION
The encoded name did not match between create and delete.